### PR TITLE
Harden service tokens and fix plugin imports

### DIFF
--- a/modules/bot-private/src/commands/antiraid.js
+++ b/modules/bot-private/src/commands/antiraid.js
@@ -1,6 +1,6 @@
 import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
-import { PRIVATE_TOKENS } from "../services/token.js";
-import { infoEmbed } from "../../../src/utils/embeds.js";
+import { PRIVATE_TOKENS } from "../services/tokens.js";
+import { infoEmbed } from "../../../../src/utils/embeds.js";
 
 const svc = (ix) => ix.client.container.get(PRIVATE_TOKENS.AntiRaidService);
 

--- a/modules/bot-private/src/index.js
+++ b/modules/bot-private/src/index.js
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
-import { fileURLToPath } from "node:url";
-import { PRIVATE_TOKENS } from "./services/token.js";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { PRIVATE_TOKENS } from "./services/tokens.js";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
@@ -27,10 +27,11 @@ export default {
       async register(container) {
         const { AntiRaidService } = await import("./services/AntiRaidService.js");
 
-        // 👉 go up THREE levels from modules/bot-private/src to project root /src
-        const { CONFIG } = await import("../../../src/config.js");
-        const { TOKENS } = await import("../../../src/container.js");
-        const { ChannelMapService } = await import("../../../src/services/ChannelMapService.js");
+        // Resolve the host project's src/ directory relative to this plugin.
+        const rootSrc = resolve(__dirname, "../../..", "src");
+        const fromSrc = (rel) => pathToFileURL(resolve(rootSrc, rel)).href;
+        const { CONFIG } = await import(fromSrc("config.js"));
+        const { TOKENS } = await import(fromSrc("container.js"));
 
         const getModLog = async (g) => {
           try {

--- a/src/commands/admin/channelmap.js
+++ b/src/commands/admin/channelmap.js
@@ -1,4 +1,5 @@
 import { ChannelType, PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { TOKENS } from "../../container.js";
 import { infoEmbed, listEmbed } from "../../utils/embeds.js";
 
 export default {
@@ -26,7 +27,7 @@ export default {
     if (!interaction.inGuild()) {
       return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Channel Map", "Guild only.")] });
     }
-    const svc = interaction.client.container.get("ChannelMapService");
+    const svc = interaction.client.container.get(TOKENS.ChannelMapService);
     const sub = interaction.options.getSubcommand();
 
     if (sub === "set") {

--- a/src/commands/admin/debug.js
+++ b/src/commands/admin/debug.js
@@ -1,4 +1,5 @@
 import { PermissionFlagsBits, SlashCommandBuilder, ChannelType, MessageFlags } from "discord.js";
+import { TOKENS } from "../../container.js";
 import { infoEmbed, listEmbed } from "../../utils/embeds.js";
 
 export default {
@@ -33,8 +34,8 @@ export default {
   async execute(interaction) {
     if (!interaction.inGuild()) return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Debug", "Guild only.")] });
 
-    const logger = interaction.client.container.get("Logger");
-    const debugState = interaction.client.container.get("DebugState");
+    const logger = interaction.client.container.get(TOKENS.Logger);
+    const debugState = interaction.client.container.get(TOKENS.DebugState);
     const sub = interaction.options.getSubcommand();
 
     if (sub === "status") {

--- a/src/commands/moderation/ban.js
+++ b/src/commands/moderation/ban.js
@@ -1,4 +1,5 @@
 import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { TOKENS } from "../../container.js";
 import { infoEmbed } from "../../utils/embeds.js";
 
 export default {
@@ -14,7 +15,7 @@ export default {
     const member = await interaction.guild.members.fetch(user.id).catch(() => null);
     if (!member) return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Ban", "User not in guild.")] });
 
-    const mod = interaction.client.container.get("ModerationService");
+    const mod = interaction.client.container.get(TOKENS.ModerationService);
     try {
       await mod.ban(member, reason);
       return interaction.reply({ embeds: [infoEmbed("Ban", `Banned **${user.tag}**\n**Reason:** ${reason}`)] });

--- a/src/commands/moderation/purge.js
+++ b/src/commands/moderation/purge.js
@@ -1,4 +1,5 @@
 import { PermissionFlagsBits, SlashCommandBuilder, ChannelType, MessageFlags } from "discord.js";
+import { TOKENS } from "../../container.js";
 import { infoEmbed } from "../../utils/embeds.js";
 
 export default {
@@ -12,7 +13,7 @@ export default {
       return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Purge", "Use in a text channel.")] });
     }
     const amount = interaction.options.getInteger("amount", true);
-    const svc = interaction.client.container.get("ModerationService");
+    const svc = interaction.client.container.get(TOKENS.ModerationService);
     try {
       const deleted = await svc.bulkDelete(interaction.channel, amount);
       return interaction.reply({ embeds: [infoEmbed("Purge", `Deleted **${deleted}** message(s).`)] });

--- a/src/commands/moderation/warn.js
+++ b/src/commands/moderation/warn.js
@@ -1,4 +1,5 @@
 import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { TOKENS } from "../../container.js";
 import { infoEmbed } from "../../utils/embeds.js";
 
 export default {
@@ -11,7 +12,7 @@ export default {
     if (!interaction.inGuild()) return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Warn", "Guild only.")] });
     const target = interaction.options.getUser("user", true);
     const reason = interaction.options.getString("reason") || "No reason provided.";
-    const svc = interaction.client.container.get("WarningService");
+    const svc = interaction.client.container.get(TOKENS.WarningService);
     await svc.add(interaction.guildId, target.id, interaction.user.id, reason);
     return interaction.reply({ embeds: [infoEmbed("Warn", `Warned **${target.tag}**\n**Reason:** ${reason}`)] });
   },

--- a/src/commands/moderation/warnings.js
+++ b/src/commands/moderation/warnings.js
@@ -1,4 +1,5 @@
 import { SlashCommandBuilder, MessageFlags } from "discord.js";
+import { TOKENS } from "../../container.js";
 import { listEmbed } from "../../utils/embeds.js";
 
 export default {
@@ -10,7 +11,7 @@ export default {
       return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [listEmbed("Warnings", ["Guild only."])] });
     }
     const user = interaction.options.getUser("user", true);
-    const svc = interaction.client.container.get("WarningService");
+    const svc = interaction.client.container.get(TOKENS.WarningService);
     const list = await svc.list(interaction.guildId, user.id, 10);
     const lines = list.length
       ? list.map(w => `• ${w.reason} — <t:${Math.floor(new Date(w.createdAt).getTime()/1000)}:R> by <@${w.modId}>`)

--- a/src/container.js
+++ b/src/container.js
@@ -8,6 +8,8 @@ export class Container {
 }
 
 export const TOKENS = {
+  Logger: "Logger",
+  DebugState: "DebugState",
   WarningService: "WarningService",
   ModerationService: "ModerationService",
   ChannelMapService: "ChannelMapService",

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -1,5 +1,6 @@
 import { replyEph, followUpEph } from "../utils/respond.js";
 import { hasDefaultPerms, hasAppLevelPerms } from "../utils/permissions.js";
+import { TOKENS } from "../container.js";
 
 export default {
   name: "interactionCreate",
@@ -11,7 +12,7 @@ export default {
     const cmd = commands.get(interaction.commandName);
     if (!cmd) return;
 
-    const logger = interaction.client.container.get("Logger");
+    const logger = interaction.client.container.get(TOKENS.Logger);
     const started = Date.now();
     const meta = {
       user: `${interaction.user.tag} (${interaction.user.id})`,

--- a/src/events/messageCreate.spam-guard.js
+++ b/src/events/messageCreate.spam-guard.js
@@ -33,7 +33,7 @@ export default {
     const container = message.client?.container;
     if (!container) return;
 
-    const logger = container.get("Logger");
+    const logger = container.get(TOKENS.Logger);
     const member = await ensureGuildMember(message);
     if (!member) return;
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import { Container, TOKENS } from "./container.js";
 import { WarningService } from "./services/WarningService.js";
 import { ModerationService } from "./services/ModerationService.js";
 import { ChannelMapService } from "./services/ChannelMapService.js";
-import { StaffRoleService } from "./services/StaffRoleService.js"; // ← added
+import { StaffRoleService } from "./services/StaffRoleService.js";
 import { AntiSpamService } from "./services/AntiSpamService.js";
 import { loadDirCommands, loadDirEvents, loadPlugins } from "./core/loader.js";
 import { Logger } from "./utils/logger.js";
@@ -20,14 +20,14 @@ async function main() {
   // Logger + Debug state
   const debugState = { channelId: CONFIG.debugChannelId || "" };
   const logger = new Logger({ level: CONFIG.logLevel, mirrorFn: null });
-  container.set("Logger", logger);
-  container.set("DebugState", debugState);
+  container.set(TOKENS.Logger, logger);
+  container.set(TOKENS.DebugState, debugState);
 
   // Core services
   container.set(TOKENS.WarningService, new WarningService());
   container.set(TOKENS.ModerationService, new ModerationService(logger));
   container.set(TOKENS.ChannelMapService, new ChannelMapService());
-  container.set(TOKENS.StaffRoleService, new StaffRoleService()); // ← added
+  container.set(TOKENS.StaffRoleService, new StaffRoleService());
   container.set(TOKENS.AntiSpamService, new AntiSpamService(CONFIG.antiSpam));
 
   // Plugins


### PR DESCRIPTION
## Summary
- add explicit container tokens for the logger/debug state and update core commands/events to resolve services through the token map
- repair the private anti-raid plugin to import its token registry and shared helpers from the correct locations while resolving host modules reliably

## Testing
- npm run check:commands

------
https://chatgpt.com/codex/tasks/task_e_68e1eb864908832b878e42e6404cc310