### PR TITLE
Generalize moderation timers and case tracking

### DIFF
--- a/src/commands/moderation/ban.js
+++ b/src/commands/moderation/ban.js
@@ -1,33 +1,73 @@
 import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
 import { TOKENS } from "../../container.js";
 import { infoEmbed } from "../../utils/embeds.js";
+import { parseDuration } from "../../utils/time.js";
 
 export default {
   data: new SlashCommandBuilder()
     .setName("ban").setDescription("Ban a member")
     .addUserOption(o => o.setName("user").setDescription("User to ban").setRequired(true))
     .addStringOption(o => o.setName("reason").setDescription("Reason"))
+    .addStringOption(o => o.setName("duration").setDescription("Duration (e.g. 7d12h)"))
     .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
   async execute(interaction) {
-    if (!interaction.inGuild()) return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Ban", "Guild only.")] });
+    if (!interaction.inGuild()) {
+      return interaction.reply({
+        flags: MessageFlags.Ephemeral,
+        embeds: [infoEmbed("Ban", "Guild only.")]
+      });
+    }
     const user = interaction.options.getUser("user", true);
     const reason = interaction.options.getString("reason") || "No reason provided.";
+    const durationInput = interaction.options.getString("duration");
+
+    let parsedDuration = null;
+    if (durationInput) {
+      try {
+        parsedDuration = parseDuration(durationInput);
+        if (!parsedDuration?.ms) parsedDuration = null;
+      } catch (err) {
+        return interaction.reply({
+          flags: MessageFlags.Ephemeral,
+          embeds: [infoEmbed("Ban", `Invalid duration: ${err?.message || err}`)]
+        });
+      }
+    }
+
     const member = await interaction.guild.members.fetch(user.id).catch(() => null);
-    if (!member) return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Ban", "User not in guild.")] });
+    if (!member) {
+      return interaction.reply({
+        flags: MessageFlags.Ephemeral,
+        embeds: [infoEmbed("Ban", "User not in guild.")]
+      });
+    }
 
     const mod = interaction.client.container.get(TOKENS.ModerationService);
     try {
-      await mod.ban(member, reason);
-      return interaction.reply({ embeds: [infoEmbed("Ban", `Banned **${user.tag}**\n**Reason:** ${reason}`)] });
+      await mod.ban({
+        guild: interaction.guild,
+        target: member,
+        moderator: interaction.user,
+        reason,
+        durationMs: parsedDuration?.ms ?? null,
+        metadata: { commandId: interaction.commandId }
+      });
+      const durationText = parsedDuration?.human ? `\n**Duration:** ${parsedDuration.human}` : "";
+      return interaction.reply({
+        embeds: [infoEmbed("Ban", `Banned **${user.tag}**\n**Reason:** ${reason}${durationText}`)]
+      });
     } catch (e) {
-      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Ban", `Failed: ${e?.message || e}`)] });
+      return interaction.reply({
+        flags: MessageFlags.Ephemeral,
+        embeds: [infoEmbed("Ban", `Failed: ${e?.message || e}`)]
+      });
     }
   },
   meta: {
     category: "moderation",
     description: "Ban a member from the server.",
-    usage: "/ban user:@User [reason:<text>]",
-    examples: ["/ban user:@Spammer reason:raid bot"],
+    usage: "/ban user:@User [reason:<text>] [duration:<time>]",
+    examples: ["/ban user:@Spammer reason:raid bot duration:7d"],
     permissions: "Ban Members"
   }
 };

--- a/src/container.js
+++ b/src/container.js
@@ -12,6 +12,7 @@ export const TOKENS = {
   DebugState: "DebugState",
   WarningService: "WarningService",
   ModerationService: "ModerationService",
+  ModerationLogService: "ModerationLogService",
   ChannelMapService: "ChannelMapService",
   StaffRoleService: "StaffRoleService",
   AntiSpamService: "AntiSpamService"

--- a/src/db/models/ModerationAction.js
+++ b/src/db/models/ModerationAction.js
@@ -1,0 +1,29 @@
+import mongoose from "mongoose";
+
+const { Schema, model } = mongoose;
+
+const ModerationActionSchema = new Schema({
+  guildId: { type: String, required: true, index: true },
+  userId: { type: String, required: true, index: true },
+  moderatorId: { type: String, default: null, index: true },
+  action: { type: String, required: true, index: true },
+  caseNumber: { type: Number, required: true },
+  reason: { type: String, default: "No reason provided." },
+  durationMs: { type: Number, default: null },
+  expiresAt: { type: Date, default: null, index: true },
+  metadata: { type: Schema.Types.Mixed, default: {} },
+  completedAt: { type: Date, default: null },
+  undoContext: { type: Schema.Types.Mixed, default: null },
+  expungedAt: { type: Date, default: null },
+  expungedBy: { type: String, default: null },
+  expungedReason: { type: String, default: null }
+}, { timestamps: true });
+
+ModerationActionSchema.index({ guildId: 1, createdAt: -1 });
+ModerationActionSchema.index({ guildId: 1, userId: 1, createdAt: -1 });
+ModerationActionSchema.index({ guildId: 1, action: 1, createdAt: -1 });
+ModerationActionSchema.index({ guildId: 1, caseNumber: 1 }, { unique: true });
+ModerationActionSchema.index({ action: 1, completedAt: 1, expiresAt: 1 });
+ModerationActionSchema.index({ expungedAt: 1 });
+
+export const ModerationActionModel = model("ModerationAction", ModerationActionSchema);

--- a/src/db/models/ModerationCounter.js
+++ b/src/db/models/ModerationCounter.js
@@ -1,0 +1,12 @@
+import mongoose from "mongoose";
+
+const { Schema, model } = mongoose;
+
+const ModerationCounterSchema = new Schema({
+  guildId: { type: String, required: true, unique: true },
+  lastCaseNumber: { type: Number, default: 0 }
+});
+
+ModerationCounterSchema.index({ guildId: 1 }, { unique: true });
+
+export const ModerationCounterModel = model("ModerationCounter", ModerationCounterSchema);

--- a/src/events/guildBanRemove.js
+++ b/src/events/guildBanRemove.js
@@ -1,0 +1,38 @@
+import { TOKENS } from "../container.js";
+import { ModerationActionType } from "../services/moderationActions.js";
+
+export default {
+  name: "guildBanRemove",
+  async execute(ban) {
+    const guild = ban?.guild;
+    const user = ban?.user;
+    const client = guild?.client || ban?.client;
+    const container = client?.container;
+    if (!guild || !user || !container) return;
+
+    let logService;
+    let moderationService;
+    try {
+      logService = container.get(TOKENS.ModerationLogService);
+      moderationService = container.get(TOKENS.ModerationService);
+    } catch {
+      return;
+    }
+
+    if (!logService || !moderationService) return;
+
+    const entry = await logService.findLatestActive({
+      guildId: guild.id,
+      userId: user.id,
+      action: ModerationActionType.Ban
+    });
+
+    if (!entry) return;
+
+    moderationService.cancelTimerForEntry(entry);
+    await logService.markCompleted(entry._id, {
+      via: "manual",
+      liftedAt: new Date().toISOString()
+    });
+  }
+};

--- a/src/events/messageCreate.spam-guard.js
+++ b/src/events/messageCreate.spam-guard.js
@@ -64,7 +64,14 @@ export default {
     };
 
     try {
-      await moderationService.ban(member, `[Auto-ban] ${reason}`);
+      await moderationService.ban({
+        guild: message.guild,
+        target: member,
+        moderator: message.client.user,
+        reason: `[Auto-ban] ${reason}`,
+        durationMs: null,
+        metadata: { source: "antispam", messageId: message.id }
+      });
       antiSpamService.clear(message.guildId, message.author.id);
       logger?.warn?.("antispam.autoban", meta);
     } catch (err) {

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -1,7 +1,18 @@
+import { TOKENS } from "../container.js";
+
 export default {
   name: "clientReady",
   once: true,
   async execute(client) {
     console.log(`Logged in as ${client.user?.tag}`);
+
+    try {
+      const moderationService = client.container.get(TOKENS.ModerationService);
+      await moderationService.onClientReady?.();
+    } catch (err) {
+      client.container.get(TOKENS.Logger)?.error?.("moderation.init_failed", {
+        error: String(err?.message || err)
+      });
+    }
   }
 };

--- a/src/services/ModerationLogService.js
+++ b/src/services/ModerationLogService.js
@@ -1,0 +1,104 @@
+import mongoose from "mongoose";
+import { ModerationActionModel } from "../db/models/ModerationAction.js";
+import { ModerationCounterModel } from "../db/models/ModerationCounter.js";
+
+export class ModerationLogService {
+  async record({ guildId, userId, moderatorId, action, reason, durationMs, expiresAt, metadata }) {
+    const caseNumber = await this.#nextCaseNumber(guildId);
+    const doc = await ModerationActionModel.create({
+      guildId,
+      userId,
+      moderatorId: moderatorId || null,
+      action,
+      caseNumber,
+      reason: reason?.trim?.() || "No reason provided.",
+      durationMs: Number.isFinite(durationMs) ? durationMs : null,
+      expiresAt: expiresAt || null,
+      metadata: metadata || {}
+    });
+    return doc.toObject();
+  }
+
+  async markCompleted(id, undoContext = null) {
+    return ModerationActionModel.findByIdAndUpdate(
+      id,
+      { completedAt: new Date(), undoContext },
+      { new: true }
+    ).lean();
+  }
+
+  async getActiveTimedActions(action) {
+    return ModerationActionModel.find({
+      action,
+      completedAt: null,
+      expiresAt: { $ne: null },
+      expungedAt: null
+    }).sort({ expiresAt: 1 }).lean();
+  }
+
+  async getById(id) {
+    if (!id) return null;
+    return ModerationActionModel.findById(id).lean();
+  }
+
+  async getByCase(guildId, caseNumber) {
+    const numericCase = typeof caseNumber === "number" ? caseNumber : Number(caseNumber);
+    if (!guildId || Number.isNaN(numericCase)) return null;
+    return ModerationActionModel.findOne({ guildId, caseNumber: numericCase }).lean();
+  }
+
+  async findLatestActive({ guildId, userId, action }) {
+    if (!guildId || !userId || !action) return null;
+    return ModerationActionModel.findOne({
+      guildId,
+      userId,
+      action,
+      completedAt: null,
+      expungedAt: null
+    }).sort({ createdAt: -1 }).lean();
+  }
+
+  async list({ guildId, userId, action, limit = 20, beforeId, includeExpunged = false }) {
+    if (!guildId) return [];
+    const query = { guildId };
+    if (userId) query.userId = userId;
+    if (action) query.action = action;
+    if (!includeExpunged) query.expungedAt = null;
+    if (beforeId) {
+      try {
+        query._id = { $lt: new mongoose.Types.ObjectId(beforeId) };
+      } catch {
+        // ignore invalid cursors
+      }
+    }
+    const safeLimit = Math.min(Math.max(limit, 1), 100);
+    return ModerationActionModel.find(query)
+      .sort({ createdAt: -1, _id: -1 })
+      .limit(safeLimit)
+      .lean();
+  }
+
+  async expunge({ guildId, caseNumber, moderatorId, reason }) {
+    const numericCase = typeof caseNumber === "number" ? caseNumber : Number(caseNumber);
+    if (!guildId || Number.isNaN(numericCase)) return null;
+    return ModerationActionModel.findOneAndUpdate(
+      { guildId, caseNumber: numericCase, expungedAt: null },
+      {
+        expungedAt: new Date(),
+        expungedBy: moderatorId || null,
+        expungedReason: reason?.trim?.() || null
+      },
+      { new: true }
+    ).lean();
+  }
+
+  async #nextCaseNumber(guildId) {
+    if (!guildId) throw new Error("guildId required for case number allocation");
+    const counter = await ModerationCounterModel.findOneAndUpdate(
+      { guildId },
+      { $inc: { lastCaseNumber: 1 } },
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+    return counter.lastCaseNumber;
+  }
+}

--- a/src/services/ModerationService.js
+++ b/src/services/ModerationService.js
@@ -1,16 +1,197 @@
 import { PermissionsBitField } from "discord.js";
+import { ModerationActionType, normalizeReason } from "./moderationActions.js";
+import { scheduleWithMaxTimeout } from "../utils/time.js";
+
+const MAX_TIMER_KEY_SIZE = 256;
 
 export class ModerationService {
+  #logger;
+  #logService;
+  #client;
+  #timers = new Map();
+  #timedHandlers = new Map();
+
+  constructor(logger, logService) {
+    this.#logger = logger;
+    this.#logService = logService;
+    this.registerTimedActionHandler(ModerationActionType.Ban, {
+      onExpire: (entry) => this.#completeBan(entry)
+    });
+  }
+
+  setClient(client) {
+    this.#client = client;
+  }
+
   canBan(member) {
     return member.permissions.has(PermissionsBitField.Flags.BanMembers);
   }
-  async ban(target, reason) {
-    if (!target?.bannable) throw new Error("Target not bannable (role/perms).");
-    await target.ban({ reason: reason || "No reason provided." });
+
+  async onClientReady() {
+    if (!this.#logService) return;
+    for (const [action] of this.#timedHandlers.entries()) {
+      const pending = await this.#logService.getActiveTimedActions(action);
+      for (const entry of pending) {
+        if (!entry?.expiresAt || entry?.completedAt) continue;
+        const expiresAt = new Date(entry.expiresAt).getTime();
+        if (Number.isNaN(expiresAt)) continue;
+        const remaining = expiresAt - Date.now();
+        if (remaining <= 0) {
+          await this.#invokeTimedHandler(entry, "startup");
+          continue;
+        }
+        this.#scheduleTimer(entry, remaining);
+      }
+    }
   }
+
+  async ban({ guild, target, moderator, reason, durationMs, metadata }) {
+    if (!target?.bannable) throw new Error("Target not bannable (role/perms).");
+    if (!guild) throw new Error("Missing guild instance for ban.");
+
+    const normalizedReason = normalizeReason(reason);
+    const expiresAt = durationMs ? new Date(Date.now() + durationMs) : null;
+
+    await target.ban({ reason: this.#buildAuditReason(moderator, normalizedReason, expiresAt) });
+
+    let entry = null;
+    if (this.#logService) {
+      entry = await this.#logService.record({
+        guildId: guild.id,
+        userId: target.id,
+        moderatorId: moderator?.id,
+        action: ModerationActionType.Ban,
+        reason: normalizedReason,
+        durationMs: durationMs ?? null,
+        expiresAt,
+        metadata: {
+          ...(metadata || {}),
+          targetTag: target?.user?.tag || null
+        }
+      });
+    }
+
+    if (expiresAt && entry) {
+      this.#scheduleTimer(entry, expiresAt.getTime() - Date.now(), guild.id);
+    }
+
+    return entry;
+  }
+
+  registerTimedActionHandler(action, handler) {
+    if (!action) throw new Error("action is required for timed handler registration");
+    if (!handler || typeof handler.onExpire !== "function") {
+      throw new Error("Timed handler must provide an onExpire function");
+    }
+    this.#timedHandlers.set(action, handler);
+  }
+
+  cancelTimerForEntry(entry) {
+    if (!entry) return;
+    const key = this.#timerKey(entry);
+    if (!key) return;
+    this.#clearTimer(key);
+  }
+
+  async expungeCase({ guildId, caseNumber, moderatorId, reason }) {
+    if (!this.#logService) throw new Error("Moderation log service not configured");
+    const numericCase = typeof caseNumber === "number" ? caseNumber : Number(caseNumber);
+    if (!guildId || Number.isNaN(numericCase)) {
+      throw new Error("guildId and numeric caseNumber are required to expunge");
+    }
+    const entry = await this.#logService.getByCase(guildId, numericCase);
+    if (!entry || entry.expungedAt) return entry;
+    this.cancelTimerForEntry(entry);
+    return this.#logService.expunge({ guildId, caseNumber: numericCase, moderatorId, reason });
+  }
+
   async bulkDelete(textChannel, amount) {
     const clamped = Math.min(Math.max(amount, 1), 100);
     const deleted = await textChannel.bulkDelete(clamped, true);
     return deleted.size;
+  }
+
+  #scheduleTimer(entry, delay, guildIdOverride = null) {
+    if (!entry?._id || !entry?.expiresAt) return;
+    const handler = this.#timedHandlers.get(entry.action || ModerationActionType.Ban);
+    if (!handler?.onExpire) return;
+    const key = this.#timerKey(entry);
+    this.#clearTimer(key);
+    if (delay <= 0) {
+      const payload = { ...entry, guildId: guildIdOverride || entry.guildId };
+      void this.#invokeTimedHandler(payload, "timer");
+      return;
+    }
+    const action = () => {
+      this.#timers.delete(key);
+      const payload = { ...entry, guildId: guildIdOverride || entry.guildId };
+      void this.#invokeTimedHandler(payload, "timer");
+    };
+    const timerHandle = scheduleWithMaxTimeout(action, delay);
+    this.#timers.set(key, timerHandle);
+  }
+
+  #clearTimer(key) {
+    const timer = this.#timers.get(key);
+    if (!timer) return;
+    try { timer.cancel?.(); } catch {}
+    this.#timers.delete(key);
+  }
+
+  async #invokeTimedHandler(entry, source) {
+    if (!entry) return;
+    const action = entry.action || ModerationActionType.Ban;
+    const handler = this.#timedHandlers.get(action);
+    if (!handler?.onExpire) return;
+    try {
+      await handler.onExpire(entry, { source, action });
+    } catch (err) {
+      this.#logger?.error?.("moderation.timed_action.expire_failed", {
+        entryId: String(entry?._id || entry?.id || "unknown"),
+        action,
+        source,
+        error: String(err?.message || err)
+      });
+    }
+  }
+
+  async #completeBan(entry) {
+    if (!entry) return;
+    const entryId = String(entry?._id || entry?.id || "");
+    if (this.#logService && entryId) {
+      const fresh = await this.#logService.getById(entryId);
+      if (!fresh || fresh.completedAt || fresh.expungedAt) return;
+    }
+    const guildId = entry.guildId;
+    if (!guildId) return;
+    if (!this.#client) throw new Error("ModerationService client not attached");
+    const guild = await this.#client.guilds.fetch(guildId).catch(() => null);
+    if (!guild) return;
+    try {
+      await guild.bans.remove(entry.userId, "Timed ban expired");
+    } catch (err) {
+      if (err?.code === 10026 || /unknown ban/i.test(err?.message || "")) {
+        // Already unbanned
+      } else {
+        throw err;
+      }
+    }
+    if (this.#logService && entryId) {
+      await this.#logService.markCompleted(entryId, { liftedAt: new Date().toISOString(), via: "auto" });
+    }
+  }
+
+  #buildAuditReason(moderator, reason, expiresAt) {
+    const base = normalizeReason(reason);
+    const modTag = moderator?.tag || moderator?.user?.tag;
+    const durationSuffix = expiresAt ? ` (until ${expiresAt.toISOString()})` : "";
+    if (modTag) return `${base} - by ${modTag}${durationSuffix}`.slice(0, 512);
+    return `${base}${durationSuffix}`.slice(0, 512);
+  }
+
+  #timerKey(entry) {
+    const idPart = typeof entry?._id === "string" ? entry._id : entry?._id?.toString?.() || entry?.id || "";
+    const key = `${entry.action || ModerationActionType.Ban}:${entry.guildId}:${entry.userId}:${idPart}`;
+    return key.length > MAX_TIMER_KEY_SIZE ? key.slice(-MAX_TIMER_KEY_SIZE) : key;
   }
 }

--- a/src/services/WarningService.js
+++ b/src/services/WarningService.js
@@ -1,9 +1,31 @@
 import { WarningModel } from "../db/models/Warning.js";
+import { ModerationActionType, normalizeReason } from "./moderationActions.js";
 
 export class WarningService {
-  async add(guildId, userId, modId, reason) {
-    return WarningModel.create({ guildId, userId, modId, reason });
+  #logService;
+  constructor(logService) {
+    this.#logService = logService;
   }
+
+  async add(guildId, userId, modId, reason) {
+    const normalizedReason = normalizeReason(reason);
+    const doc = await WarningModel.create({ guildId, userId, modId, reason: normalizedReason });
+    const warning = doc.toObject();
+    if (this.#logService) {
+      await this.#logService.record({
+        guildId,
+        userId,
+        moderatorId: modId,
+        action: ModerationActionType.Warn,
+        reason: normalizedReason,
+        durationMs: null,
+        expiresAt: null,
+        metadata: { warningId: warning._id?.toString?.() }
+      });
+    }
+    return warning;
+  }
+
   async list(guildId, userId, limit = 10) {
     return WarningModel.find({ guildId, userId }).sort({ createdAt: -1 }).limit(limit).lean();
   }

--- a/src/services/moderationActions.js
+++ b/src/services/moderationActions.js
@@ -1,0 +1,13 @@
+export const ModerationActionType = Object.freeze({
+  Ban: "ban",
+  Kick: "kick",
+  Mute: "mute",
+  Warn: "warn"
+});
+
+export const DEFAULT_MOD_REASON = "No reason provided.";
+
+export function normalizeReason(reason) {
+  const text = reason?.trim?.();
+  return text?.length ? text : DEFAULT_MOD_REASON;
+}

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,145 @@
+const UNIT_MS = {
+  ms: 1,
+  millisecond: 1,
+  milliseconds: 1,
+  s: 1_000,
+  sec: 1_000,
+  secs: 1_000,
+  second: 1_000,
+  seconds: 1_000,
+  m: 60_000,
+  min: 60_000,
+  mins: 60_000,
+  minute: 60_000,
+  minutes: 60_000,
+  h: 3_600_000,
+  hr: 3_600_000,
+  hrs: 3_600_000,
+  hour: 3_600_000,
+  hours: 3_600_000,
+  d: 86_400_000,
+  day: 86_400_000,
+  days: 86_400_000,
+  w: 604_800_000,
+  week: 604_800_000,
+  weeks: 604_800_000,
+  mo: 2_592_000_000,
+  mos: 2_592_000_000,
+  month: 2_592_000_000,
+  months: 2_592_000_000,
+  y: 31_536_000_000,
+  yr: 31_536_000_000,
+  yrs: 31_536_000_000,
+  year: 31_536_000_000,
+  years: 31_536_000_000
+};
+
+const DURATION_PATTERN = /(\d+(?:\.\d+)?)\s*([a-zA-Z]+)/g;
+const PERMANENT_KEYWORDS = new Set(["perma", "permanent", "perm", "forever", "infinite", "indefinite"]);
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+export function parseDuration(input, { defaultUnit = "m" } = {}) {
+  if (!input) return null;
+  const trimmed = String(input).trim();
+  if (!trimmed) return null;
+  const lower = trimmed.toLowerCase();
+  if (PERMANENT_KEYWORDS.has(lower)) return { ms: null, human: "permanent", parts: [] };
+
+  let match;
+  let total = 0;
+  const parts = [];
+  DURATION_PATTERN.lastIndex = 0;
+  while ((match = DURATION_PATTERN.exec(lower))) {
+    const value = Number(match[1]);
+    const unitRaw = match[2];
+    const unit = UNIT_MS[unitRaw] ? unitRaw : normalizeUnit(unitRaw);
+    const multiplier = UNIT_MS[unit];
+    if (!Number.isFinite(value) || !multiplier) throw new Error(`Unknown duration unit: ${unitRaw}`);
+    const ms = value * multiplier;
+    total += ms;
+    parts.push({ value, unit });
+  }
+
+  if (total === 0) {
+    if (!/^[0-9]+$/.test(lower)) throw new Error("Invalid duration format");
+    const value = Number(lower);
+    if (!Number.isFinite(value) || value <= 0) throw new Error("Invalid duration value");
+    const multiplier = UNIT_MS[defaultUnit] || UNIT_MS.m;
+    total = value * multiplier;
+    parts.push({ value, unit: defaultUnit });
+  }
+
+  if (total <= 0) throw new Error("Duration must be greater than zero");
+
+  return { ms: Math.round(total), human: formatDuration(total), parts };
+}
+
+export function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return "0s";
+  const units = [
+    { label: "y", value: 31_536_000_000 },
+    { label: "mo", value: 2_592_000_000 },
+    { label: "w", value: 604_800_000 },
+    { label: "d", value: 86_400_000 },
+    { label: "h", value: 3_600_000 },
+    { label: "m", value: 60_000 },
+    { label: "s", value: 1_000 }
+  ];
+  const segments = [];
+  let remaining = ms;
+  for (const unit of units) {
+    if (remaining < unit.value) continue;
+    const qty = Math.floor(remaining / unit.value);
+    remaining -= qty * unit.value;
+    segments.push(`${qty}${unit.label}`);
+  }
+  if (!segments.length) return "<1s";
+  return segments.join(" ");
+}
+
+export function scheduleWithMaxTimeout(callback, ms) {
+  if (typeof callback !== "function") throw new TypeError("callback must be a function");
+  let remaining = Math.max(0, ms);
+  if (!Number.isFinite(remaining) || remaining === 0) {
+    if (remaining === 0) callback();
+    return { cancel: () => {} };
+  }
+  let cancelled = false;
+  let handle = null;
+
+  const schedule = () => {
+    if (cancelled) return;
+    const nextDelay = Math.min(remaining, MAX_TIMEOUT_MS);
+    handle = setTimeout(() => {
+      if (cancelled) return;
+      if (remaining > MAX_TIMEOUT_MS) {
+        remaining -= MAX_TIMEOUT_MS;
+        schedule();
+      } else {
+        cancelled = true;
+        callback();
+      }
+    }, nextDelay);
+  };
+
+  schedule();
+
+  return {
+    cancel() {
+      cancelled = true;
+      if (handle) {
+        clearTimeout(handle);
+        handle = null;
+      }
+    }
+  };
+}
+
+function normalizeUnit(unitRaw) {
+  const lower = unitRaw.toLowerCase();
+  if (UNIT_MS[lower]) return lower;
+  if (lower.endsWith("s") && UNIT_MS[lower.slice(0, -1)]) return lower.slice(0, -1);
+  throw new Error(`Unknown duration unit: ${unitRaw}`);
+}
+
+export const MAX_TIMEOUT_DURATION = MAX_TIMEOUT_MS;


### PR DESCRIPTION
## Summary
- assign sequential case numbers and expunge metadata to moderation actions backed by a per-guild counter model
- extend the moderation log service with query helpers, case lookups, and expunge support while preventing stale timers from expunged entries
- generalize the moderation service timed-action scheduler, expose timer cancellation/expunge helpers, and clear manual unbans via a new guildBanRemove event handler

## Testing
- npm run check:commands

------
https://chatgpt.com/codex/tasks/task_e_68e1eda2f1f4832b95e086c387c06796