### PR TITLE
Fix duplicate guildId index definitions

### DIFF
--- a/src/db/models/ChannelMap.js
+++ b/src/db/models/ChannelMap.js
@@ -2,7 +2,7 @@ import mongoose from "mongoose";
 const { Schema, model } = mongoose;
 
 const ChannelMapSchema = new Schema({
-  guildId:   { type: String, required: true, index: true },
+  guildId:   { type: String, required: true },
   key:       { type: String, required: true },
   channelId: { type: String, required: true },
   note:      { type: String, default: "" }

--- a/src/db/models/ModerationAction.js
+++ b/src/db/models/ModerationAction.js
@@ -3,10 +3,10 @@ import mongoose from "mongoose";
 const { Schema, model } = mongoose;
 
 const ModerationActionSchema = new Schema({
-  guildId: { type: String, required: true, index: true },
-  userId: { type: String, required: true, index: true },
+  guildId: { type: String, required: true },
+  userId: { type: String, required: true },
   moderatorId: { type: String, default: null, index: true },
-  action: { type: String, required: true, index: true },
+  action: { type: String, required: true },
   caseNumber: { type: Number, required: true },
   reason: { type: String, default: "No reason provided." },
   durationMs: { type: Number, default: null },

--- a/src/db/models/ModerationCounter.js
+++ b/src/db/models/ModerationCounter.js
@@ -7,6 +7,4 @@ const ModerationCounterSchema = new Schema({
   lastCaseNumber: { type: Number, default: 0 }
 });
 
-ModerationCounterSchema.index({ guildId: 1 }, { unique: true });
-
 export const ModerationCounterModel = model("ModerationCounter", ModerationCounterSchema);

--- a/src/db/models/StaffRole.js
+++ b/src/db/models/StaffRole.js
@@ -3,8 +3,8 @@ const { Schema, model } = mongoose;
 
 /** Map guild -> staff role IDs, keyed by label (e.g., "admin", "mod"). */
 const StaffRoleSchema = new Schema({
-  guildId: { type: String, required: true, index: true },
-  key:     { type: String, required: true, index: true },   // "admin", "mod", etc.
+  guildId: { type: String, required: true },
+  key:     { type: String, required: true },   // "admin", "mod", etc.
   roleId:  { type: String, required: true }
 }, { timestamps: true });
 

--- a/src/db/models/Warning.js
+++ b/src/db/models/Warning.js
@@ -2,8 +2,8 @@ import mongoose from "mongoose";
 const { Schema, model } = mongoose;
 
 const WarningSchema = new Schema({
-  guildId: { type: String, required: true, index: true },
-  userId:  { type: String, required: true, index: true },
+  guildId: { type: String, required: true },
+  userId:  { type: String, required: true },
   modId:   { type: String, required: true },
   reason:  { type: String, default: "No reason provided." }
 }, { timestamps: true });


### PR DESCRIPTION
## Summary
- remove redundant field-level indexes from guild-scoped schemas to eliminate duplicate index warnings
- rely on the existing compound and unique schema indexes for query performance and constraints

## Testing
- node --input-type=module -e "import('./src/db/models/Warning.js');import('./src/db/models/ChannelMap.js');import('./src/db/models/ModerationAction.js');import('./src/db/models/ModerationCounter.js');"


------
https://chatgpt.com/codex/tasks/task_e_68e1f85b0900832b854ff050e49b2c32