### PR TITLE
Add moderation command suite

### DIFF
--- a/src/commands/moderation/automod.js
+++ b/src/commands/moderation/automod.js
@@ -1,0 +1,37 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+import { TOKENS } from "../../container.js";
+
+function buildChoiceOption(option) {
+  return option.addStringOption(o => o.setName("state").setDescription("Enable or disable").setRequired(true).addChoices(
+    { name: "on", value: "on" },
+    { name: "off", value: "off" }
+  ));
+}
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("automod")
+    .setDescription("Toggle AutoMod integrations")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+    .addSubcommand(s => buildChoiceOption(s.setName("invite-block").setDescription("Block Discord invite links")))
+    .addSubcommand(s => buildChoiceOption(s.setName("profanity").setDescription("Enable profanity filter"))),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Automod", "Guild only.")] });
+    }
+
+    const sub = interaction.options.getSubcommand();
+    const state = interaction.options.getString("state", true) === "on";
+    const runtime = interaction.client.container.get(TOKENS.RuntimeModerationState);
+    runtime.setAutomod(interaction.guildId, sub, state);
+    return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Automod", `${sub.replace("-", " ")} is now **${state ? "ENABLED" : "disabled"}**.`)] });
+  },
+  meta: {
+    category: "moderation",
+    description: "Toggle Discord AutoMod style features.",
+    usage: "/automod invite-block state:on",
+    examples: ["/automod profanity state:on"],
+    permissions: "Manage Server"
+  }
+};

--- a/src/commands/moderation/case.js
+++ b/src/commands/moderation/case.js
@@ -1,0 +1,58 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { infoEmbed, listEmbed } from "../../utils/embeds.js";
+import { TOKENS } from "../../container.js";
+
+function formatCase(entry) {
+  const lines = [
+    `**Case:** #${entry.caseNumber}`,
+    `**User:** <@${entry.userId}>`,
+    `**Action:** ${entry.action}`,
+    `**Reason:** ${entry.reason || "No reason"}`
+  ];
+  if (entry.durationMs) lines.push(`**Duration:** ${Math.round(entry.durationMs / 1000)}s`);
+  return lines.join("\n");
+}
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("case")
+    .setDescription("Moderation case lookup")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+    .addSubcommand(s => s
+      .setName("show")
+      .setDescription("Show a specific case")
+      .addIntegerOption(o => o.setName("id").setDescription("Case number").setRequired(true)))
+    .addSubcommand(s => s
+      .setName("search")
+      .setDescription("Search cases for a user")
+      .addUserOption(o => o.setName("user").setDescription("User").setRequired(true))),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Case", "Guild only.")] });
+    }
+
+    const svc = interaction.client.container.get(TOKENS.ModerationLogService);
+    const sub = interaction.options.getSubcommand();
+
+    if (sub === "show") {
+      const id = interaction.options.getInteger("id", true);
+      const entry = await svc.getByCase(interaction.guildId, id);
+      if (!entry) {
+        return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Case", "Case not found.")] });
+      }
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed(`Case #${entry.caseNumber}`, formatCase(entry))] });
+    }
+
+    const user = interaction.options.getUser("user", true);
+    const entries = await svc.list({ guildId: interaction.guildId, userId: user.id, limit: 10 });
+    const lines = entries.map(e => `#${e.caseNumber} — ${e.action} — ${e.reason}`);
+    return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [listEmbed(`Cases for ${user.tag}`, lines, "No cases found.")] });
+  },
+  meta: {
+    category: "moderation",
+    description: "Search the moderation case log.",
+    usage: "/case show id:42 | /case search user:@User",
+    examples: ["/case show id:100", "/case search user:@Trouble"],
+    permissions: "Moderate Members"
+  }
+};

--- a/src/commands/moderation/health.js
+++ b/src/commands/moderation/health.js
@@ -1,0 +1,42 @@
+import { PermissionFlagsBits, SlashCommandBuilder, ChannelType, MessageFlags } from "discord.js";
+import { listEmbed } from "../../utils/embeds.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("health")
+    .setDescription("Guild health checks")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+    .addSubcommand(s => s.setName("perms").setDescription("Audit common permission mistakes")),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [listEmbed("Health", [], "Guild only.")] });
+    }
+
+    const issues = [];
+    const everyone = interaction.guild.roles.everyone;
+    interaction.guild.channels.cache.forEach(channel => {
+      if (channel.type !== ChannelType.GuildText) return;
+      const perms = channel.permissionsFor(everyone);
+      if (!perms) return;
+      if (perms.has(PermissionFlagsBits.ManageMessages)) {
+        issues.push(`${channel}: @everyone can Manage Messages`);
+      }
+      if (perms.has(PermissionFlagsBits.ManageChannels)) {
+        issues.push(`${channel}: @everyone can Manage Channels`);
+      }
+      if (perms.has(PermissionFlagsBits.MentionEveryone)) {
+        issues.push(`${channel}: @everyone can Mention @everyone`);
+      }
+    });
+
+    const embed = listEmbed("Permission Audit", issues, "No obvious permission risks detected.");
+    return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [embed] });
+  },
+  meta: {
+    category: "moderation",
+    description: "Check for risky permission grants.",
+    usage: "/health perms",
+    examples: ["/health perms"],
+    permissions: "Manage Server"
+  }
+};

--- a/src/commands/moderation/history.js
+++ b/src/commands/moderation/history.js
@@ -1,0 +1,34 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { listEmbed } from "../../utils/embeds.js";
+import { TOKENS } from "../../container.js";
+
+function formatEntry(entry) {
+  const when = `<t:${Math.floor(new Date(entry.createdAt).getTime() / 1000)}:R>`;
+  return `#${entry.caseNumber} — ${entry.action} — ${entry.reason} (${when})`;
+}
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("history")
+    .setDescription("Show a user's moderation history")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+    .addUserOption(o => o.setName("user").setDescription("User").setRequired(true)),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [listEmbed("History", [], "Guild only.")] });
+    }
+
+    const user = interaction.options.getUser("user", true);
+    const svc = interaction.client.container.get(TOKENS.ModerationLogService);
+    const entries = await svc.list({ guildId: interaction.guildId, userId: user.id, limit: 20 });
+    const lines = entries.map(formatEntry);
+    return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [listEmbed(`History for ${user.tag}`, lines, "No history found.")] });
+  },
+  meta: {
+    category: "moderation",
+    description: "Display recent actions taken against a user.",
+    usage: "/history user:@User",
+    examples: ["/history user:@Trouble"],
+    permissions: "Moderate Members"
+  }
+};

--- a/src/commands/moderation/kick.js
+++ b/src/commands/moderation/kick.js
@@ -1,0 +1,42 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("kick")
+    .setDescription("Kick a member from the server")
+    .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers)
+    .addUserOption(o => o.setName("user").setDescription("Target user").setRequired(true))
+    .addStringOption(o => o.setName("reason").setDescription("Reason")),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Kick", "Guild only.")] });
+    }
+
+    const target = interaction.options.getUser("user", true);
+    const reason = interaction.options.getString("reason") || "No reason provided.";
+    const member = await interaction.guild.members.fetch(target.id).catch(() => null);
+
+    if (!member) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Kick", "User not found in guild.")] });
+    }
+
+    if (!member.kickable) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Kick", "Cannot kick this member.")] });
+    }
+
+    try {
+      await member.kick(reason);
+      return interaction.reply({ embeds: [infoEmbed("Kick", `Kicked **${target.tag}**.\nReason: ${reason}`)] });
+    } catch (err) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Kick", `Failed: ${err?.message || err}`)] });
+    }
+  },
+  meta: {
+    category: "moderation",
+    description: "Kick a member from the guild.",
+    usage: "/kick user:@User [reason:<text>]",
+    examples: ["/kick user:@Spammer reason:raid"],
+    permissions: "Kick Members"
+  }
+};

--- a/src/commands/moderation/links.js
+++ b/src/commands/moderation/links.js
@@ -1,0 +1,90 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { infoEmbed, listEmbed } from "../../utils/embeds.js";
+import { TOKENS } from "../../container.js";
+
+const ruleDescription = (rule) => `• **${rule.type}** — ${rule.value}`;
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("links")
+    .setDescription("Manage link allow/deny lists")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+    .addSubcommandGroup(g => g
+      .setName("allow")
+      .setDescription("Allowlist controls")
+      .addSubcommand(s => s
+        .setName("add")
+        .setDescription("Add an allowed link rule")
+        .addStringOption(o => o.setName("type").setDescription("Match type").setRequired(true).addChoices(
+          { name: "pattern", value: "pattern" },
+          { name: "exact", value: "exact" }
+        ))
+        .addStringOption(o => o.setName("value").setDescription("Value to allow").setRequired(true)))
+      .addSubcommand(s => s
+        .setName("remove")
+        .setDescription("Remove an allowed link rule")
+        .addStringOption(o => o.setName("value").setDescription("Value to remove").setRequired(true)))
+      .addSubcommand(s => s
+        .setName("list")
+        .setDescription("List allowed link rules")))
+    .addSubcommandGroup(g => g
+      .setName("deny")
+      .setDescription("Deny list controls")
+      .addSubcommand(s => s
+        .setName("add")
+        .setDescription("Add a denied link rule")
+        .addStringOption(o => o.setName("type").setDescription("Match type").setRequired(true).addChoices(
+          { name: "pattern", value: "pattern" },
+          { name: "exact", value: "exact" }
+        ))
+        .addStringOption(o => o.setName("value").setDescription("Value to deny").setRequired(true)))
+      .addSubcommand(s => s
+        .setName("remove")
+        .setDescription("Remove a denied link rule")
+        .addStringOption(o => o.setName("value").setDescription("Value to remove").setRequired(true)))
+      .addSubcommand(s => s
+        .setName("list")
+        .setDescription("List denied link rules")))
+    .addSubcommand(s => s
+      .setName("test")
+      .setDescription("Test a URL against the rules")
+      .addStringOption(o => o.setName("url").setDescription("URL to test").setRequired(true))),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Links", "Guild only.")] });
+    }
+
+    const runtime = interaction.client.container.get(TOKENS.RuntimeModerationState);
+    const group = interaction.options.getSubcommandGroup(false);
+    const sub = interaction.options.getSubcommand();
+
+    if (!group) {
+      const url = interaction.options.getString("url", true);
+      const result = runtime.testLink(interaction.guildId, url);
+      const resText = result.result === "none" ? "No rules matched." : `Matched **${result.result}** (${result.rule?.type ?? "?"} → ${result.rule?.value ?? ""}).`;
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Links Test", resText)] });
+    }
+
+    const kind = group;
+    if (sub === "add") {
+      const type = interaction.options.getString("type", true) === "exact" ? "exact" : "pattern";
+      const value = interaction.options.getString("value", true);
+      runtime.addLinkRule(interaction.guildId, kind, { type, value });
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Links", `${kind === "allow" ? "Allow" : "Deny"} rule added for **${value}** (${type}).`)] });
+    }
+    if (sub === "remove") {
+      const value = interaction.options.getString("value", true);
+      const removed = runtime.removeLinkRule(interaction.guildId, kind, value);
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Links", removed ? `Removed ${kind} rule for **${value}**.` : "No matching rule.")] });
+    }
+    const rules = runtime.listLinkRules(interaction.guildId, kind).map(ruleDescription);
+    return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [listEmbed(`${kind === "allow" ? "Allowed" : "Denied"} links`, rules)] });
+  },
+  meta: {
+    category: "moderation",
+    description: "Manage link allow/deny rules.",
+    usage: "/links allow add type:pattern value:example.com",
+    examples: ["/links allow list", "/links deny add type:exact value:bad.com"],
+    permissions: "Manage Server"
+  }
+};

--- a/src/commands/moderation/lock.js
+++ b/src/commands/moderation/lock.js
@@ -1,0 +1,44 @@
+import { PermissionFlagsBits, SlashCommandBuilder, ChannelType, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+
+function resolveChannel(interaction) {
+  const channel = interaction.options.getChannel("channel") || interaction.channel;
+  if (!channel || channel.type !== ChannelType.GuildText) return null;
+  return channel;
+}
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("lock")
+    .setDescription("Lock a text channel")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
+    .addChannelOption(o => o.setName("channel").setDescription("Channel to lock").addChannelTypes(ChannelType.GuildText))
+    .addStringOption(o => o.setName("reason").setDescription("Reason")),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Lock", "Guild only.")] });
+    }
+
+    const channel = resolveChannel(interaction);
+    if (!channel) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Lock", "Select a text channel.")] });
+    }
+
+    const reason = interaction.options.getString("reason") || "Channel locked";
+    const everyone = interaction.guild.roles.everyone;
+
+    try {
+      await channel.permissionOverwrites.edit(everyone, { SendMessages: false, AddReactions: false }, `${reason} (by ${interaction.user.tag})`);
+      return interaction.reply({ embeds: [infoEmbed("Lock", `Locked ${channel}.\nReason: ${reason}`)] });
+    } catch (err) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Lock", `Failed: ${err?.message || err}`)] });
+    }
+  },
+  meta: {
+    category: "moderation",
+    description: "Prevent @everyone from sending messages in a text channel.",
+    usage: "/lock [channel:#general] [reason:<text>]",
+    examples: ["/lock channel:#general reason:raid"],
+    permissions: "Manage Channels"
+  }
+};

--- a/src/commands/moderation/massmention.js
+++ b/src/commands/moderation/massmention.js
@@ -1,0 +1,34 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+import { TOKENS } from "../../container.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("massmention")
+    .setDescription("Configure mass mention limit")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+    .addSubcommandGroup(g => g
+      .setName("limit")
+      .setDescription("Limit settings")
+      .addSubcommand(s => s
+        .setName("set")
+        .setDescription("Set mention limit")
+        .addIntegerOption(o => o.setName("count").setDescription("Mentions per message").setRequired(true).setMinValue(1)))),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Massmention", "Guild only.")] });
+    }
+
+    const limit = interaction.options.getInteger("count", true);
+    const runtime = interaction.client.container.get(TOKENS.RuntimeModerationState);
+    runtime.setMassMentionLimit(interaction.guildId, limit);
+    return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Massmention", `Limit set to **${limit}** mentions per message.`)] });
+  },
+  meta: {
+    category: "moderation",
+    description: "Limit how many users can be mentioned per message.",
+    usage: "/massmention limit set count:5",
+    examples: ["/massmention limit set count:3"],
+    permissions: "Manage Server"
+  }
+};

--- a/src/commands/moderation/modlog.js
+++ b/src/commands/moderation/modlog.js
@@ -1,0 +1,48 @@
+import { PermissionFlagsBits, SlashCommandBuilder, ChannelType, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+import { GuildConfigModel } from "../../db/models/GuildConfig.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("modlog")
+    .setDescription("Manage moderation log channel")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+    .addSubcommand(s => s.setName("where").setDescription("Show the current modlog channel"))
+    .addSubcommand(s => s
+      .setName("set")
+      .setDescription("Set the modlog channel")
+      .addChannelOption(o => o.setName("channel").setDescription("Channel").setRequired(true).addChannelTypes(ChannelType.GuildText))),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Modlog", "Guild only.")] });
+    }
+
+    const sub = interaction.options.getSubcommand();
+
+    if (sub === "where") {
+      const config = await GuildConfigModel.findOne({ guildId: interaction.guildId }).lean();
+      const channel = config?.modLogChannelId ? `<#${config.modLogChannelId}>` : "Not configured.";
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Modlog", `Current channel: ${channel}`)] });
+    }
+
+    const channel = interaction.options.getChannel("channel", true);
+    if (!channel || channel.type !== ChannelType.GuildText) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Modlog", "Select a text channel.")] });
+    }
+
+    await GuildConfigModel.findOneAndUpdate(
+      { guildId: interaction.guildId },
+      { modLogChannelId: channel.id },
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+
+    return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Modlog", `Set modlog channel to ${channel}.`)] });
+  },
+  meta: {
+    category: "moderation",
+    description: "Configure where moderation logs are sent.",
+    usage: "/modlog where | /modlog set channel:#logs",
+    examples: ["/modlog set channel:#mod-log"],
+    permissions: "Manage Server"
+  }
+};

--- a/src/commands/moderation/note.js
+++ b/src/commands/moderation/note.js
@@ -1,0 +1,51 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { infoEmbed, listEmbed } from "../../utils/embeds.js";
+import { TOKENS } from "../../container.js";
+
+function formatNote(note) {
+  const author = note.authorId ? `<@${note.authorId}>` : "Unknown";
+  const ts = note.createdAt instanceof Date ? note.createdAt.toISOString() : new Date(note.createdAt).toISOString();
+  return `• ${note.text} — ${author} (${ts})`;
+}
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("note")
+    .setDescription("Add or view moderator notes")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+    .addSubcommand(s => s
+      .setName("add")
+      .setDescription("Add a note for a user")
+      .addUserOption(o => o.setName("user").setDescription("User").setRequired(true))
+      .addStringOption(o => o.setName("text").setDescription("Note text").setRequired(true)))
+    .addSubcommand(s => s
+      .setName("list")
+      .setDescription("List notes for a user")
+      .addUserOption(o => o.setName("user").setDescription("User").setRequired(true))),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Note", "Guild only.")] });
+    }
+
+    const runtime = interaction.client.container.get(TOKENS.RuntimeModerationState);
+    const sub = interaction.options.getSubcommand();
+    const user = interaction.options.getUser("user", true);
+
+    if (sub === "add") {
+      const text = interaction.options.getString("text", true);
+      runtime.addNote(interaction.guildId, user.id, interaction.user.id, text);
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Note", `Added note for **${user.tag}**.`)] });
+    }
+
+    const notes = runtime.getNotes(interaction.guildId, user.id);
+    const lines = notes.map(formatNote);
+    return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [listEmbed(`Notes for ${user.tag}`, lines, "No notes recorded.")] });
+  },
+  meta: {
+    category: "moderation",
+    description: "Maintain informal notes about users.",
+    usage: "/note add user:@User text:Spoke to them | /note list user:@User",
+    examples: ["/note add user:@Helper text:Great helper"],
+    permissions: "Moderate Members"
+  }
+};

--- a/src/commands/moderation/purge.js
+++ b/src/commands/moderation/purge.js
@@ -1,31 +1,135 @@
 import { PermissionFlagsBits, SlashCommandBuilder, ChannelType, MessageFlags } from "discord.js";
-import { TOKENS } from "../../container.js";
 import { infoEmbed } from "../../utils/embeds.js";
+
+const MAX_FETCH_ITERATIONS = 10;
+const BULK_DELETE_WINDOW = 13 * 24 * 60 * 60 * 1000; // just under 14 days
+
+async function fetchMessages(channel, beforeId) {
+  return channel.messages.fetch({ limit: 100, before: beforeId || undefined }).catch(() => null);
+}
+
+async function collectMessages(channel, predicate, amount) {
+  const collected = [];
+  let before;
+  for (let i = 0; i < MAX_FETCH_ITERATIONS && collected.length < amount; i++) {
+    const batch = await fetchMessages(channel, before);
+    if (!batch || batch.size === 0) break;
+    const sorted = [...batch.values()].sort((a, b) => b.createdTimestamp - a.createdTimestamp);
+    for (const message of sorted) {
+      if (Date.now() - message.createdTimestamp > BULK_DELETE_WINDOW) continue;
+      if (predicate(message)) collected.push(message);
+      if (collected.length >= amount) break;
+    }
+    before = sorted.at(-1)?.id;
+    if (!before) break;
+  }
+  return collected;
+}
+
+async function deleteMessages(channel, messages) {
+  if (!messages.length) return 0;
+  const ids = messages.map(m => m.id);
+  const deleted = await channel.bulkDelete(ids, true).catch(() => null);
+  return deleted?.size || 0;
+}
+
+function ensureTextChannel(interaction) {
+  const { channel } = interaction;
+  if (!channel || !channel.isTextBased?.() || channel.type !== ChannelType.GuildText) {
+    return false;
+  }
+  return true;
+}
 
 export default {
   data: new SlashCommandBuilder()
-    .setName("purge").setDescription("Bulk delete recent messages (1-100)")
-    .addIntegerOption(o => o.setName("amount").setDescription("Number to delete").setRequired(true).setMinValue(1).setMaxValue(100))
-    .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages),
+    .setName("purge")
+    .setDescription("Bulk delete messages with filters")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageMessages)
+    .addSubcommand(s => s
+      .setName("recent")
+      .setDescription("Delete the most recent messages")
+      .addIntegerOption(o => o.setName("count").setDescription("Number to delete").setRequired(true).setMinValue(1).setMaxValue(100)))
+    .addSubcommand(s => s
+      .setName("user")
+      .setDescription("Delete recent messages from a user")
+      .addUserOption(o => o.setName("user").setDescription("User to target").setRequired(true))
+      .addIntegerOption(o => o.setName("count").setDescription("Number to delete").setRequired(true).setMinValue(1).setMaxValue(100)))
+    .addSubcommand(s => s
+      .setName("contains")
+      .setDescription("Delete messages containing text")
+      .addStringOption(o => o.setName("text").setDescription("Substring to match").setRequired(true))
+      .addIntegerOption(o => o.setName("count").setDescription("Number to delete").setRequired(true).setMinValue(1).setMaxValue(100)))
+    .addSubcommand(s => s
+      .setName("links")
+      .setDescription("Delete recent messages containing links")
+      .addIntegerOption(o => o.setName("count").setDescription("Number to delete").setRequired(true).setMinValue(1).setMaxValue(100)))
+    .addSubcommand(s => s
+      .setName("invites")
+      .setDescription("Delete recent messages containing invites")
+      .addIntegerOption(o => o.setName("count").setDescription("Number to delete").setRequired(true).setMinValue(1).setMaxValue(100)))
+    .addSubcommand(s => s
+      .setName("bots")
+      .setDescription("Delete recent bot messages")
+      .addIntegerOption(o => o.setName("count").setDescription("Number to delete").setRequired(true).setMinValue(1).setMaxValue(100))),
   async execute(interaction) {
-    if (!interaction.inGuild()) return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Purge", "Guild only.")] });
-    if (interaction.channel?.type !== ChannelType.GuildText) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Purge", "Guild only.")] });
+    }
+    if (!ensureTextChannel(interaction)) {
       return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Purge", "Use in a text channel.")] });
     }
-    const amount = interaction.options.getInteger("amount", true);
-    const svc = interaction.client.container.get(TOKENS.ModerationService);
+
+    await interaction.deferReply({ ephemeral: true });
+
+    const sub = interaction.options.getSubcommand();
+    const { channel } = interaction;
+    let deleted = 0;
+
     try {
-      const deleted = await svc.bulkDelete(interaction.channel, amount);
-      return interaction.reply({ embeds: [infoEmbed("Purge", `Deleted **${deleted}** message(s).`)] });
-    } catch (e) {
-      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Purge", `Failed: ${e?.message || e}`)] });
+      if (sub === "recent") {
+        const count = interaction.options.getInteger("count", true);
+        deleted = await channel.bulkDelete(count, true).then(col => col.size).catch(() => 0);
+      } else if (sub === "user") {
+        const user = interaction.options.getUser("user", true);
+        const count = interaction.options.getInteger("count", true);
+        const msgs = await collectMessages(channel, (m) => m.author?.id === user.id, count);
+        deleted = await deleteMessages(channel, msgs);
+      } else if (sub === "contains") {
+        const text = interaction.options.getString("text", true).toLowerCase();
+        const count = interaction.options.getInteger("count", true);
+        const msgs = await collectMessages(channel, (m) => (m.content || "").toLowerCase().includes(text), count);
+        deleted = await deleteMessages(channel, msgs);
+      } else if (sub === "links") {
+        const count = interaction.options.getInteger("count", true);
+        const linkRegex = /https?:\/\/|discord\.gg\//i;
+        const msgs = await collectMessages(channel, (m) => linkRegex.test(m.content || "") || (m.embeds?.length ?? 0) > 0 || (m.attachments?.size ?? 0) > 0, count);
+        deleted = await deleteMessages(channel, msgs);
+      } else if (sub === "invites") {
+        const count = interaction.options.getInteger("count", true);
+        const inviteRegex = /discord\.gg\//i;
+        const msgs = await collectMessages(channel, (m) => inviteRegex.test(m.content || ""), count);
+        deleted = await deleteMessages(channel, msgs);
+      } else if (sub === "bots") {
+        const count = interaction.options.getInteger("count", true);
+        const msgs = await collectMessages(channel, (m) => Boolean(m.author?.bot), count);
+        deleted = await deleteMessages(channel, msgs);
+      }
+    } catch (err) {
+      return interaction.editReply({ embeds: [infoEmbed("Purge", `Failed: ${err?.message || err}`)] });
     }
+
+    return interaction.editReply({ embeds: [infoEmbed("Purge", `Deleted **${deleted}** message(s).`)] });
   },
   meta: {
     category: "moderation",
-    description: "Delete the last N messages in the current channel.",
-    usage: "/purge amount:<1-100>",
-    examples: ["/purge amount:25"],
+    description: "Delete recent messages with optional filters.",
+    usage: "/purge <recent|user|contains|links|invites|bots>",
+    examples: [
+      "/purge recent count:25",
+      "/purge user user:@Spammer count:10",
+      "/purge contains text:spam count:15"
+    ],
     permissions: "Manage Messages"
   }
 };

--- a/src/commands/moderation/quarantine.js
+++ b/src/commands/moderation/quarantine.js
@@ -1,0 +1,47 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+
+function findQuarantineRole(guild) {
+  const byName = guild.roles.cache.find(r => /quarantine|restricted/i.test(r.name));
+  return byName || null;
+}
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("quarantine")
+    .setDescription("Move a member into a restricted role")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageRoles)
+    .addUserOption(o => o.setName("user").setDescription("Target user").setRequired(true))
+    .addStringOption(o => o.setName("reason").setDescription("Reason")),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Quarantine", "Guild only.")] });
+    }
+
+    const target = interaction.options.getUser("user", true);
+    const reason = interaction.options.getString("reason") || "Quarantined";
+    const member = await interaction.guild.members.fetch(target.id).catch(() => null);
+    if (!member) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Quarantine", "User not found in guild.")] });
+    }
+
+    const role = findQuarantineRole(interaction.guild);
+    if (!role) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Quarantine", "No quarantine/restricted role found.")] });
+    }
+
+    try {
+      await member.roles.add(role, `${reason} (by ${interaction.user.tag})`);
+      return interaction.reply({ embeds: [infoEmbed("Quarantine", `Assigned **${role.name}** to **${target.tag}**.`)] });
+    } catch (err) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Quarantine", `Failed: ${err?.message || err}`)] });
+    }
+  },
+  meta: {
+    category: "moderation",
+    description: "Assign a restricted role to a member.",
+    usage: "/quarantine user:@User [reason:<text>]",
+    examples: ["/quarantine user:@Trouble reason:Spamming invites"],
+    permissions: "Manage Roles"
+  }
+};

--- a/src/commands/moderation/raidmode.js
+++ b/src/commands/moderation/raidmode.js
@@ -1,0 +1,31 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+import { TOKENS } from "../../container.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("raidmode")
+    .setDescription("Toggle hardened raid mode")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+    .addStringOption(o => o.setName("state").setDescription("on or off").setRequired(true).addChoices(
+      { name: "on", value: "on" },
+      { name: "off", value: "off" }
+    )),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Raidmode", "Guild only.")] });
+    }
+
+    const state = interaction.options.getString("state", true) === "on";
+    const runtime = interaction.client.container.get(TOKENS.RuntimeModerationState);
+    runtime.setRaidMode(interaction.guildId, state);
+    return interaction.reply({ embeds: [infoEmbed("Raidmode", `Raidmode is now **${state ? "ON" : "OFF"}**.`)] });
+  },
+  meta: {
+    category: "security",
+    description: "Toggle raid hardening mode.",
+    usage: "/raidmode on|off",
+    examples: ["/raidmode on"],
+    permissions: "Manage Server"
+  }
+};

--- a/src/commands/moderation/reason.js
+++ b/src/commands/moderation/reason.js
@@ -1,0 +1,34 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+import { TOKENS } from "../../container.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("reason")
+    .setDescription("Update the reason for a moderation case")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+    .addIntegerOption(o => o.setName("case_id").setDescription("Case number").setRequired(true))
+    .addStringOption(o => o.setName("reason").setDescription("New reason").setRequired(true)),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Reason", "Guild only.")] });
+    }
+
+    const caseId = interaction.options.getInteger("case_id", true);
+    const reason = interaction.options.getString("reason", true);
+    const svc = interaction.client.container.get(TOKENS.ModerationLogService);
+
+    const updated = await svc.updateReason({ guildId: interaction.guildId, caseNumber: caseId, reason });
+    if (!updated) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Reason", "Case not found.")] });
+    }
+    return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Reason", `Updated case #${updated.caseNumber}.`)] });
+  },
+  meta: {
+    category: "moderation",
+    description: "Edit the reason for a logged moderation action.",
+    usage: "/reason case_id:42 reason:Updated reason",
+    examples: ["/reason case_id:25 reason:Appeal accepted"],
+    permissions: "Moderate Members"
+  }
+};

--- a/src/commands/moderation/slowmode.js
+++ b/src/commands/moderation/slowmode.js
@@ -1,0 +1,54 @@
+import { PermissionFlagsBits, SlashCommandBuilder, ChannelType, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+
+function resolveTargetChannel(interaction, optionName = "channel") {
+  const channel = interaction.options.getChannel(optionName) || interaction.channel;
+  if (!channel || channel.type !== ChannelType.GuildText) return null;
+  return channel;
+}
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("slowmode")
+    .setDescription("Configure channel slowmode")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
+    .addSubcommand(s => s
+      .setName("set")
+      .setDescription("Enable slowmode")
+      .addChannelOption(o => o.setName("channel").setDescription("Channel").addChannelTypes(ChannelType.GuildText))
+      .addIntegerOption(o => o.setName("seconds").setDescription("Slowmode duration").setRequired(true).setMinValue(1).setMaxValue(21600)))
+    .addSubcommand(s => s
+      .setName("off")
+      .setDescription("Disable slowmode")
+      .addChannelOption(o => o.setName("channel").setDescription("Channel").addChannelTypes(ChannelType.GuildText))),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Slowmode", "Guild only.")] });
+    }
+
+    const sub = interaction.options.getSubcommand();
+    const channel = resolveTargetChannel(interaction);
+    if (!channel) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Slowmode", "Select a text channel.")] });
+    }
+
+    try {
+      if (sub === "set") {
+        const seconds = interaction.options.getInteger("seconds", true);
+        await channel.setRateLimitPerUser(seconds, `Set by ${interaction.user.tag}`);
+        return interaction.reply({ embeds: [infoEmbed("Slowmode", `Set slowmode in ${channel} to **${seconds}s**.`)] });
+      }
+      await channel.setRateLimitPerUser(0, `Cleared by ${interaction.user.tag}`);
+      return interaction.reply({ embeds: [infoEmbed("Slowmode", `Disabled slowmode in ${channel}.`)] });
+    } catch (err) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Slowmode", `Failed: ${err?.message || err}`)] });
+    }
+  },
+  meta: {
+    category: "moderation",
+    description: "Enable or disable slowmode for a text channel.",
+    usage: "/slowmode set [channel:#general] seconds:30 | /slowmode off [channel:#general]",
+    examples: ["/slowmode set seconds:10", "/slowmode off channel:#general"],
+    permissions: "Manage Channels"
+  }
+};

--- a/src/commands/moderation/spam.js
+++ b/src/commands/moderation/spam.js
@@ -1,0 +1,73 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+import { TOKENS } from "../../container.js";
+import { parseDuration } from "../../utils/time.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("spam")
+    .setDescription("Configure anti-spam settings")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild)
+    .addSubcommandGroup(g => g
+      .setName("thresholds")
+      .setDescription("Rate limits")
+      .addSubcommand(s => s
+        .setName("set")
+        .setDescription("Set spam thresholds")
+        .addIntegerOption(o => o.setName("msgs_per_window").setDescription("Messages per window").setRequired(true).setMinValue(1))
+        .addIntegerOption(o => o.setName("links_per_window").setDescription("Links per window").setRequired(true).setMinValue(0))
+        .addIntegerOption(o => o.setName("window_sec").setDescription("Window duration in seconds").setRequired(true).setMinValue(5))))
+    .addSubcommandGroup(g => g
+      .setName("action")
+      .setDescription("Automatic action")
+      .addSubcommand(s => s
+        .setName("set")
+        .setDescription("Set spam action")
+        .addStringOption(o => o.setName("value").setDescription("warn | timeout:<dur> | ban").setRequired(true)))),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Spam", "Guild only.")] });
+    }
+
+    const runtime = interaction.client.container.get(TOKENS.RuntimeModerationState);
+    const group = interaction.options.getSubcommandGroup();
+
+    if (group === "thresholds") {
+      const msgs = interaction.options.getInteger("msgs_per_window", true);
+      const links = interaction.options.getInteger("links_per_window", true);
+      const windowSec = interaction.options.getInteger("window_sec", true);
+      runtime.setSpamThresholds(interaction.guildId, { msgs, links, windowSec });
+      const antiSpam = interaction.client.container.get(TOKENS.AntiSpamService);
+      antiSpam.cfg.msgMaxInWindow = msgs;
+      antiSpam.cfg.linkMaxInWindow = links;
+      antiSpam.cfg.msgWindowMs = windowSec * 1000;
+      antiSpam.cfg.linkWindowMs = windowSec * 1000;
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Spam", `Thresholds updated: **${msgs} msgs / ${links} links** per **${windowSec}s**.`)] });
+    }
+
+    const value = interaction.options.getString("value", true).toLowerCase();
+    if (value === "warn" || value === "ban") {
+      runtime.setSpamAction(interaction.guildId, value);
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Spam", `Spam action set to **${value}**.`)] });
+    }
+    if (value.startsWith("timeout:")) {
+      const durationInput = value.split(":")[1];
+      try {
+        const parsed = parseDuration(durationInput);
+        if (!parsed?.ms) throw new Error("Invalid duration");
+        runtime.setSpamAction(interaction.guildId, `timeout:${parsed.ms}`);
+        return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Spam", `Spam action set to **timeout ${parsed.human || durationInput}**.`)] });
+      } catch (err) {
+        return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Spam", `Invalid timeout duration: ${err?.message || err}`)] });
+      }
+    }
+    return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Spam", "Unknown action. Use warn, ban, or timeout:<duration>.")] });
+  },
+  meta: {
+    category: "moderation",
+    description: "Adjust anti-spam thresholds and enforcement.",
+    usage: "/spam thresholds set msgs_per_window:10 links_per_window:5 window_sec:30",
+    examples: ["/spam action set value:timeout:10m"],
+    permissions: "Manage Server"
+  }
+};

--- a/src/commands/moderation/thread.js
+++ b/src/commands/moderation/thread.js
@@ -1,0 +1,45 @@
+import { PermissionFlagsBits, SlashCommandBuilder, ChannelType, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+
+const THREAD_TYPES = [ChannelType.PublicThread, ChannelType.PrivateThread, ChannelType.AnnouncementThread];
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("thread")
+    .setDescription("Thread moderation tools")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageThreads)
+    .addSubcommand(s => s
+      .setName("lock")
+      .setDescription("Lock a thread")
+      .addChannelOption(o => o.setName("thread").setDescription("Thread").setRequired(true).addChannelTypes(...THREAD_TYPES)))
+    .addSubcommand(s => s
+      .setName("archive")
+      .setDescription("Archive a thread")
+      .addChannelOption(o => o.setName("thread").setDescription("Thread").setRequired(true).addChannelTypes(...THREAD_TYPES))),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Thread", "Guild only.")] });
+    }
+
+    const sub = interaction.options.getSubcommand();
+    const thread = interaction.options.getChannel("thread", true);
+
+    try {
+      if (sub === "lock") {
+        await thread.setLocked(true, `Locked by ${interaction.user.tag}`);
+        return interaction.reply({ embeds: [infoEmbed("Thread", `Locked ${thread}.`)] });
+      }
+      await thread.setArchived(true, `Archived by ${interaction.user.tag}`);
+      return interaction.reply({ embeds: [infoEmbed("Thread", `Archived ${thread}.`)] });
+    } catch (err) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Thread", `Failed: ${err?.message || err}`)] });
+    }
+  },
+  meta: {
+    category: "moderation",
+    description: "Lock or archive threads.",
+    usage: "/thread lock thread:<#thread> | /thread archive thread:<#thread>",
+    examples: ["/thread lock thread:#support-thread"],
+    permissions: "Manage Threads"
+  }
+};

--- a/src/commands/moderation/timeout.js
+++ b/src/commands/moderation/timeout.js
@@ -1,0 +1,60 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+import { parseDuration } from "../../utils/time.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("timeout")
+    .setDescription("Timeout a member for a duration")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+    .addUserOption(o => o.setName("user").setDescription("Target user").setRequired(true))
+    .addStringOption(o => o.setName("duration").setDescription("Duration (e.g. 30m, 1h30m)").setRequired(true))
+    .addStringOption(o => o.setName("reason").setDescription("Reason")),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Timeout", "Guild only.")] });
+    }
+
+    const target = interaction.options.getUser("user", true);
+    const durationInput = interaction.options.getString("duration", true);
+    const reason = interaction.options.getString("reason") || "No reason provided.";
+
+    let durationMs;
+    try {
+      const parsed = parseDuration(durationInput);
+      if (!parsed?.ms) throw new Error("Invalid duration");
+      durationMs = parsed.ms;
+    } catch (err) {
+      return interaction.reply({
+        flags: MessageFlags.Ephemeral,
+        embeds: [infoEmbed("Timeout", `Invalid duration: ${err?.message || err}`)]
+      });
+    }
+
+    const member = await interaction.guild.members.fetch(target.id).catch(() => null);
+    if (!member) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Timeout", "User not found in guild.")] });
+    }
+
+    if (!member.moderatable) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Timeout", "Cannot timeout this member.")] });
+    }
+
+    try {
+      await member.timeout(durationMs, reason);
+      return interaction.reply({ embeds: [infoEmbed("Timeout", `Timed out **${target.tag}** for **${durationInput}**\nReason: ${reason}`)] });
+    } catch (err) {
+      return interaction.reply({
+        flags: MessageFlags.Ephemeral,
+        embeds: [infoEmbed("Timeout", `Failed to timeout: ${err?.message || err}`)]
+      });
+    }
+  },
+  meta: {
+    category: "moderation",
+    description: "Timeout a member for a set duration.",
+    usage: "/timeout user:@User duration:30m [reason:<text>]",
+    examples: ["/timeout user:@Spammer duration:15m reason:Spam"],
+    permissions: "Timeout Members"
+  }
+};

--- a/src/commands/moderation/unban.js
+++ b/src/commands/moderation/unban.js
@@ -1,0 +1,42 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("unban")
+    .setDescription("Remove a guild ban")
+    .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
+    .addStringOption(o => o.setName("user").setDescription("User ID or tag").setRequired(true))
+    .addStringOption(o => o.setName("reason").setDescription("Reason")),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Unban", "Guild only.")] });
+    }
+
+    const input = interaction.options.getString("user", true);
+    const reason = interaction.options.getString("reason") || "No reason provided.";
+    const bans = await interaction.guild.bans.fetch().catch(() => null);
+    if (!bans) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Unban", "Unable to fetch ban list.")] });
+    }
+
+    const ban = bans.find(b => b.user.id === input || b.user.tag === input);
+    if (!ban) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Unban", "Ban not found.")] });
+    }
+
+    try {
+      await interaction.guild.bans.remove(ban.user.id, reason);
+      return interaction.reply({ embeds: [infoEmbed("Unban", `Removed ban for **${ban.user.tag}**.`)] });
+    } catch (err) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Unban", `Failed: ${err?.message || err}`)] });
+    }
+  },
+  meta: {
+    category: "moderation",
+    description: "Remove a ban from the guild.",
+    usage: "/unban user:<id|tag> [reason:<text>]",
+    examples: ["/unban user:123456789012345678 reason:Appealed"],
+    permissions: "Ban Members"
+  }
+};

--- a/src/commands/moderation/unlock.js
+++ b/src/commands/moderation/unlock.js
@@ -1,0 +1,42 @@
+import { PermissionFlagsBits, SlashCommandBuilder, ChannelType, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+
+function resolveChannel(interaction) {
+  const channel = interaction.options.getChannel("channel") || interaction.channel;
+  if (!channel || channel.type !== ChannelType.GuildText) return null;
+  return channel;
+}
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("unlock")
+    .setDescription("Unlock a text channel")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels)
+    .addChannelOption(o => o.setName("channel").setDescription("Channel to unlock").addChannelTypes(ChannelType.GuildText)),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Unlock", "Guild only.")] });
+    }
+
+    const channel = resolveChannel(interaction);
+    if (!channel) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Unlock", "Select a text channel.")] });
+    }
+
+    const everyone = interaction.guild.roles.everyone;
+
+    try {
+      await channel.permissionOverwrites.edit(everyone, { SendMessages: null, AddReactions: null }, `Unlock by ${interaction.user.tag}`);
+      return interaction.reply({ embeds: [infoEmbed("Unlock", `Unlocked ${channel}.`)] });
+    } catch (err) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Unlock", `Failed: ${err?.message || err}`)] });
+    }
+  },
+  meta: {
+    category: "moderation",
+    description: "Allow @everyone to send messages again in a text channel.",
+    usage: "/unlock [channel:#general]",
+    examples: ["/unlock channel:#general"],
+    permissions: "Manage Channels"
+  }
+};

--- a/src/commands/moderation/untimeout.js
+++ b/src/commands/moderation/untimeout.js
@@ -1,0 +1,45 @@
+import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
+import { infoEmbed } from "../../utils/embeds.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("untimeout")
+    .setDescription("Remove a timeout from a member")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+    .addUserOption(o => o.setName("user").setDescription("Target user").setRequired(true)),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Untimeout", "Guild only.")] });
+    }
+
+    const target = interaction.options.getUser("user", true);
+    const member = await interaction.guild.members.fetch(target.id).catch(() => null);
+    if (!member) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [infoEmbed("Untimeout", "User not found in guild.")] });
+    }
+
+    if (!member.isCommunicationDisabled()) {
+      return interaction.reply({
+        flags: MessageFlags.Ephemeral,
+        embeds: [infoEmbed("Untimeout", "Member is not currently timed out.")]
+      });
+    }
+
+    try {
+      await member.timeout(null, "Timeout cleared via command");
+      return interaction.reply({ embeds: [infoEmbed("Untimeout", `Removed timeout for **${target.tag}**.`)] });
+    } catch (err) {
+      return interaction.reply({
+        flags: MessageFlags.Ephemeral,
+        embeds: [infoEmbed("Untimeout", `Failed to remove timeout: ${err?.message || err}`)]
+      });
+    }
+  },
+  meta: {
+    category: "moderation",
+    description: "Remove an active communication timeout.",
+    usage: "/untimeout user:@User",
+    examples: ["/untimeout user:@Spammer"],
+    permissions: "Timeout Members"
+  }
+};

--- a/src/commands/moderation/whois.js
+++ b/src/commands/moderation/whois.js
@@ -1,0 +1,61 @@
+import { SlashCommandBuilder, MessageFlags, EmbedBuilder, PermissionFlagsBits } from "discord.js";
+import { TOKENS } from "../../container.js";
+
+function formatDate(date) {
+  if (!date) return "Unknown";
+  return `<t:${Math.floor(new Date(date).getTime() / 1000)}:R>`;
+}
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("whois")
+    .setDescription("Display information about a user")
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+    .addUserOption(o => o.setName("user").setDescription("User").setRequired(true)),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: "Use this command in a server." });
+    }
+
+    const target = interaction.options.getUser("user", true);
+    const member = await interaction.guild.members.fetch(target.id).catch(() => null);
+    const svc = interaction.client.container.get(TOKENS.ModerationLogService);
+    const cases = await svc.list({ guildId: interaction.guildId, userId: target.id, limit: 5 });
+
+    const roles = member ? member.roles.cache.filter(r => r.id !== interaction.guild.roles.everyone.id).map(r => r.toString()).join(", ") || "None" : "Not in guild";
+    const embed = new EmbedBuilder()
+      .setTitle(`Whois: ${target.tag}`)
+      .setThumbnail(target.displayAvatarURL({ size: 256 }))
+      .addFields(
+        { name: "User ID", value: target.id, inline: true },
+        { name: "Account Created", value: formatDate(target.createdAt), inline: true },
+        { name: "Joined Server", value: member ? formatDate(member.joinedAt) : "Not present", inline: true },
+        { name: "Roles", value: roles },
+        { name: "Recent Cases", value: cases.length ? cases.map(c => `#${c.caseNumber} — ${c.action}`).join("\n") : "No recent cases" }
+      )
+      .setTimestamp(new Date());
+
+    const perms = member?.permissions?.toArray?.() || [];
+    if (perms.length) {
+      const keyPerms = perms.filter(name => [
+        "Administrator",
+        "ManageGuild",
+        "ManageMessages",
+        "BanMembers",
+        "KickMembers"
+      ].includes(name));
+      if (keyPerms.length) {
+        embed.addFields({ name: "Key Permissions", value: keyPerms.map(p => `• ${p}`).join("\n") });
+      }
+    }
+
+    return interaction.reply({ flags: MessageFlags.Ephemeral, embeds: [embed] });
+  },
+  meta: {
+    category: "moderation",
+    description: "Show key details about a member.",
+    usage: "/whois user:@User",
+    examples: ["/whois user:@Member"],
+    permissions: "Moderate Members"
+  }
+};

--- a/src/container.js
+++ b/src/container.js
@@ -15,5 +15,6 @@ export const TOKENS = {
   ModerationLogService: "ModerationLogService",
   ChannelMapService: "ChannelMapService",
   StaffRoleService: "StaffRoleService",
-  AntiSpamService: "AntiSpamService"
+  AntiSpamService: "AntiSpamService",
+  RuntimeModerationState: "RuntimeModerationState"
 };

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import { loadDirCommands, loadDirEvents, loadPlugins } from "./core/loader.js";
 import { Logger } from "./utils/logger.js";
 import mongoose from "mongoose";
 import { ModerationLogService } from "./services/ModerationLogService.js";
+import { RuntimeModerationState } from "./services/RuntimeModerationState.js";
 
 async function main() {
   await connectMongo();
@@ -37,6 +38,7 @@ async function main() {
   container.set(TOKENS.ChannelMapService, new ChannelMapService());
   container.set(TOKENS.StaffRoleService, new StaffRoleService());
   container.set(TOKENS.AntiSpamService, new AntiSpamService(CONFIG.antiSpam));
+  container.set(TOKENS.RuntimeModerationState, new RuntimeModerationState());
 
   // Plugins
   const pluginDirs = (CONFIG.privateModuleDirs || []).map(p => resolve(process.cwd(), p));

--- a/src/services/ModerationLogService.js
+++ b/src/services/ModerationLogService.js
@@ -92,6 +92,16 @@ export class ModerationLogService {
     ).lean();
   }
 
+  async updateReason({ guildId, caseNumber, reason }) {
+    const numericCase = typeof caseNumber === "number" ? caseNumber : Number(caseNumber);
+    if (!guildId || Number.isNaN(numericCase)) return null;
+    return ModerationActionModel.findOneAndUpdate(
+      { guildId, caseNumber: numericCase },
+      { reason: reason?.trim?.() || "No reason provided." },
+      { new: true }
+    ).lean();
+  }
+
   async #nextCaseNumber(guildId) {
     if (!guildId) throw new Error("guildId required for case number allocation");
     const counter = await ModerationCounterModel.findOneAndUpdate(

--- a/src/services/RuntimeModerationState.js
+++ b/src/services/RuntimeModerationState.js
@@ -1,0 +1,120 @@
+export class RuntimeModerationState {
+  #raidMode = new Map();
+  #linkRules = new Map();
+  #spamThresholds = new Map();
+  #spamAction = new Map();
+  #massMentionLimit = new Map();
+  #automodSettings = new Map();
+  #notes = new Map();
+
+  setRaidMode(guildId, active) {
+    this.#raidMode.set(guildId, Boolean(active));
+  }
+
+  getRaidMode(guildId) {
+    return Boolean(this.#raidMode.get(guildId));
+  }
+
+  #ensureLinkBucket(guildId) {
+    if (!this.#linkRules.has(guildId)) {
+      this.#linkRules.set(guildId, { allow: [], deny: [] });
+    }
+    return this.#linkRules.get(guildId);
+  }
+
+  addLinkRule(guildId, kind, rule) {
+    const bucket = this.#ensureLinkBucket(guildId);
+    const collection = kind === "deny" ? bucket.deny : bucket.allow;
+    const entry = { ...rule, id: `${Date.now()}-${Math.random()}` };
+    collection.push(entry);
+    return entry;
+  }
+
+  removeLinkRule(guildId, kind, value) {
+    const bucket = this.#ensureLinkBucket(guildId);
+    const collection = kind === "deny" ? bucket.deny : bucket.allow;
+    const before = collection.length;
+    const lowered = String(value).toLowerCase();
+    const filtered = collection.filter((entry) => entry.value.toLowerCase() !== lowered);
+    if (filtered.length === before) return false;
+    if (kind === "deny") bucket.deny = filtered; else bucket.allow = filtered;
+    this.#linkRules.set(guildId, bucket);
+    return true;
+  }
+
+  listLinkRules(guildId, kind) {
+    const bucket = this.#ensureLinkBucket(guildId);
+    return [...(kind === "deny" ? bucket.deny : bucket.allow)];
+  }
+
+  testLink(guildId, url) {
+    const bucket = this.#ensureLinkBucket(guildId);
+    const lower = String(url).toLowerCase();
+    const matchFn = (entry) => {
+      if (entry.type === "exact") {
+        return lower === entry.value.toLowerCase();
+      }
+      try {
+        return lower.includes(entry.value.toLowerCase());
+      } catch {
+        return false;
+      }
+    };
+    const deny = bucket.deny.find(matchFn);
+    if (deny) return { result: "deny", rule: deny };
+    const allow = bucket.allow.find(matchFn);
+    if (allow) return { result: "allow", rule: allow };
+    return { result: "none", rule: null };
+  }
+
+  setSpamThresholds(guildId, thresholds) {
+    this.#spamThresholds.set(guildId, { ...thresholds });
+  }
+
+  getSpamThresholds(guildId) {
+    return this.#spamThresholds.get(guildId) || null;
+  }
+
+  setSpamAction(guildId, action) {
+    this.#spamAction.set(guildId, action);
+  }
+
+  getSpamAction(guildId) {
+    return this.#spamAction.get(guildId) || "warn";
+  }
+
+  setMassMentionLimit(guildId, limit) {
+    this.#massMentionLimit.set(guildId, limit);
+  }
+
+  getMassMentionLimit(guildId) {
+    return this.#massMentionLimit.get(guildId) || null;
+  }
+
+  setAutomod(guildId, key, enabled) {
+    if (!this.#automodSettings.has(guildId)) {
+      this.#automodSettings.set(guildId, {});
+    }
+    const entry = this.#automodSettings.get(guildId);
+    entry[key] = Boolean(enabled);
+    this.#automodSettings.set(guildId, entry);
+  }
+
+  getAutomod(guildId, key) {
+    const entry = this.#automodSettings.get(guildId);
+    return entry ? Boolean(entry[key]) : false;
+  }
+
+  addNote(guildId, userId, authorId, text) {
+    if (!this.#notes.has(guildId)) this.#notes.set(guildId, new Map());
+    const guildNotes = this.#notes.get(guildId);
+    if (!guildNotes.has(userId)) guildNotes.set(userId, []);
+    const note = { text, authorId, createdAt: new Date() };
+    guildNotes.get(userId).push(note);
+    return note;
+  }
+
+  getNotes(guildId, userId) {
+    return this.#notes.get(guildId)?.get(userId) || [];
+  }
+}


### PR DESCRIPTION
## Summary
- add a runtime moderation state service and register it with the bot container
- implement a comprehensive set of moderation slash commands for user actions, channel controls, configuration, and logging
- extend purge and moderation log services to support new command capabilities

## Testing
- npm run check:commands

------
https://chatgpt.com/codex/tasks/task_e_68e1ff3ed5ec832b9943f77952e2e2a5