### PR TITLE
Add anti-executable attachment scanner with VirusTotal integration

### DIFF
--- a/default.configs.json
+++ b/default.configs.json
@@ -12,6 +12,20 @@
     "thresholdMs": 1800000,
     "alertChannelId": "123456789012345678"
   },
+  "fileScanner": {
+    "enabled": true,
+    "prefixBytes": 512,
+    "staffFlagChannelKey": "flag_log",
+    "staffActionChannelKey": "action_log",
+    "vtActionThreshold": 5,
+    "vtMuteDurationMs": 86400000,
+    "virusTotal": {
+      "apiKey": "YOUR_VT_API_KEY",
+      "pollIntervalMs": 5000,
+      "maxPolls": 12,
+      "maxFileBytes": 33554432
+    }
+  },
   "antiSpam": {
     "msgWindowMs": 15000,
     "msgMaxInWindow": 10,

--- a/src/config.js
+++ b/src/config.js
@@ -42,6 +42,22 @@ const brandNewDefaults = {
   alertChannelId: ""
 };
 const brandNewFileCfg = fileCfg?.brandNew || {};
+const fileScannerDefaults = {
+  enabled: true,
+  prefixBytes: 512,
+  staffFlagChannelKey: "flag_log",
+  staffActionChannelKey: "action_log",
+  vtActionThreshold: 5,
+  vtMuteDurationMs: 24 * 60 * 60_000
+};
+const fileScannerFileCfg = fileCfg?.fileScanner || {};
+const virusTotalDefaults = {
+  apiKey: "",
+  pollIntervalMs: 5000,
+  maxPolls: 12,
+  maxFileBytes: 32 * 1024 * 1024
+};
+const virusTotalFileCfg = fileScannerFileCfg?.virusTotal || fileCfg?.virusTotal || {};
 
 export const CONFIG = {
   token: envOr("DISCORD_TOKEN", fileCfg?.discord?.token || ""),
@@ -62,6 +78,20 @@ export const CONFIG = {
     enabled: toBoolean(envOr("BRAND_NEW_ENABLED", brandNewFileCfg.enabled ?? brandNewDefaults.enabled), brandNewDefaults.enabled),
     thresholdMs: toNumber(envOr("BRAND_NEW_THRESHOLD_MS", brandNewFileCfg.thresholdMs ?? brandNewDefaults.thresholdMs), brandNewDefaults.thresholdMs),
     alertChannelId: envOr("BRAND_NEW_ALERT_CHANNEL_ID", brandNewFileCfg.alertChannelId ?? brandNewDefaults.alertChannelId) || ""
+  },
+  fileScanner: {
+    enabled: toBoolean(envOr("FILE_SCANNER_ENABLED", fileScannerFileCfg.enabled ?? fileScannerDefaults.enabled), fileScannerDefaults.enabled),
+    prefixBytes: toNumber(envOr("FILE_SCANNER_PREFIX_BYTES", fileScannerFileCfg.prefixBytes ?? fileScannerDefaults.prefixBytes), fileScannerDefaults.prefixBytes),
+    staffFlagChannelKey: envOr("FILE_SCANNER_FLAG_CHANNEL_KEY", fileScannerFileCfg.staffFlagChannelKey ?? fileScannerDefaults.staffFlagChannelKey) || "",
+    staffActionChannelKey: envOr("FILE_SCANNER_ACTION_CHANNEL_KEY", fileScannerFileCfg.staffActionChannelKey ?? fileScannerDefaults.staffActionChannelKey) || "",
+    vtActionThreshold: toNumber(envOr("FILE_SCANNER_VT_THRESHOLD", fileScannerFileCfg.vtActionThreshold ?? fileScannerDefaults.vtActionThreshold), fileScannerDefaults.vtActionThreshold),
+    vtMuteDurationMs: toNumber(envOr("FILE_SCANNER_MUTE_DURATION_MS", fileScannerFileCfg.vtMuteDurationMs ?? fileScannerDefaults.vtMuteDurationMs), fileScannerDefaults.vtMuteDurationMs),
+    virusTotal: {
+      apiKey: envOr("VIRUSTOTAL_API_KEY", virusTotalFileCfg.apiKey ?? virusTotalDefaults.apiKey) || "",
+      pollIntervalMs: toNumber(envOr("VIRUSTOTAL_POLL_INTERVAL_MS", virusTotalFileCfg.pollIntervalMs ?? virusTotalDefaults.pollIntervalMs), virusTotalDefaults.pollIntervalMs),
+      maxPolls: toNumber(envOr("VIRUSTOTAL_MAX_POLLS", virusTotalFileCfg.maxPolls ?? virusTotalDefaults.maxPolls), virusTotalDefaults.maxPolls),
+      maxFileBytes: toNumber(envOr("VIRUSTOTAL_MAX_FILE_BYTES", virusTotalFileCfg.maxFileBytes ?? virusTotalDefaults.maxFileBytes), virusTotalDefaults.maxFileBytes)
+    }
   }
 };
 

--- a/src/container.js
+++ b/src/container.js
@@ -16,5 +16,6 @@ export const TOKENS = {
   ChannelMapService: "ChannelMapService",
   StaffRoleService: "StaffRoleService",
   AntiSpamService: "AntiSpamService",
-  RuntimeModerationState: "RuntimeModerationState"
+  RuntimeModerationState: "RuntimeModerationState",
+  VirusTotalService: "VirusTotalService"
 };

--- a/src/events/messageCreate.attachment-scan.js
+++ b/src/events/messageCreate.attachment-scan.js
@@ -1,0 +1,450 @@
+import { EmbedBuilder } from "discord.js";
+import { TOKENS } from "../container.js";
+import { CONFIG } from "../config.js";
+import { formatDuration } from "../utils/time.js";
+
+const EXECUTABLE_SIGNATURES = [
+  { label: "PE (Windows)", signature: [0x4d, 0x5a] },
+  { label: "ELF", signature: [0x7f, 0x45, 0x4c, 0x46] },
+  { label: "Mach-O", signature: [0xfe, 0xed, 0xfa, 0xce] },
+  { label: "Mach-O", signature: [0xce, 0xfa, 0xed, 0xfe] },
+  { label: "Mach-O (64-bit)", signature: [0xfe, 0xed, 0xfa, 0xcf] },
+  { label: "Mach-O (64-bit)", signature: [0xcf, 0xfa, 0xed, 0xfe] },
+  { label: "Mach-O (Fat)", signature: [0xca, 0xfe, 0xba, 0xbe] },
+  { label: "Mach-O (Fat)", signature: [0xbe, 0xba, 0xfe, 0xca] }
+];
+
+const ARCHIVE_SIGNATURES = [
+  { label: "ZIP", signature: [0x50, 0x4b, 0x03, 0x04] },
+  { label: "ZIP", signature: [0x50, 0x4b, 0x05, 0x06] },
+  { label: "ZIP", signature: [0x50, 0x4b, 0x07, 0x08] },
+  { label: "7z", signature: [0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c] },
+  { label: "RAR (v4)", signature: [0x52, 0x61, 0x72, 0x21, 0x1a, 0x07, 0x00] },
+  { label: "RAR (v5)", signature: [0x52, 0x61, 0x72, 0x21, 0x1a, 0x07, 0x01, 0x00] },
+  { label: "GZIP", signature: [0x1f, 0x8b] },
+  { label: "BZIP2", signature: [0x42, 0x5a, 0x68] },
+  { label: "XZ", signature: [0xfd, 0x37, 0x7a, 0x58, 0x5a, 0x00] },
+  { label: "Zstandard", signature: [0x28, 0xb5, 0x2f, 0xfd] }
+];
+
+const ZLIB_SECOND_BYTES = new Set([0x01, 0x5e, 0x9c, 0xda]);
+
+const MAX_EMBED_FIELD = 1024;
+
+function hasSignature(bytes, signature, offset = 0) {
+  if (!bytes || bytes.length < offset + signature.length) return false;
+  for (let i = 0; i < signature.length; i += 1) {
+    if (bytes[offset + i] !== signature[i]) return false;
+  }
+  return true;
+}
+
+function detectTar(bytes) {
+  if (!bytes || bytes.length < 262) return false;
+  const signature = [0x75, 0x73, 0x74, 0x61, 0x72]; // "ustar"
+  return hasSignature(bytes, signature, 257);
+}
+
+function detectZlib(bytes) {
+  if (!bytes || bytes.length < 2) return false;
+  return bytes[0] === 0x78 && ZLIB_SECOND_BYTES.has(bytes[1]);
+}
+
+function classifyBytes(bytes) {
+  for (const sig of EXECUTABLE_SIGNATURES) {
+    if (hasSignature(bytes, sig.signature, sig.offset || 0)) {
+      return { kind: "executable", label: sig.label };
+    }
+  }
+  if (detectTar(bytes)) {
+    return { kind: "archive", label: "TAR" };
+  }
+  for (const sig of ARCHIVE_SIGNATURES) {
+    if (hasSignature(bytes, sig.signature, sig.offset || 0)) {
+      return { kind: "archive", label: sig.label };
+    }
+  }
+  if (detectZlib(bytes)) {
+    return { kind: "archive", label: "Zlib" };
+  }
+  return { kind: "other", label: null };
+}
+
+async function fetchPrefix(url, maxBytes, logger, name) {
+  if (!url || maxBytes <= 0) return null;
+  const controller = new AbortController();
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) throw new Error(`status ${res.status}`);
+    if (!res.body) {
+      const arrayBuffer = await res.arrayBuffer();
+      return new Uint8Array(arrayBuffer.slice(0, maxBytes));
+    }
+    const reader = res.body.getReader();
+    const chunks = [];
+    let total = 0;
+    while (total < maxBytes) {
+      const { value, done } = await reader.read();
+      if (done || !value) break;
+      const needed = Math.min(value.length, maxBytes - total);
+      chunks.push(value.slice(0, needed));
+      total += needed;
+      if (needed < value.length) break;
+    }
+    controller.abort();
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      out.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return out;
+  } catch (error) {
+    controller.abort();
+    logger?.warn?.("file_scanner.prefix_failed", {
+      url,
+      name,
+      error: String(error?.message || error)
+    });
+    return null;
+  }
+}
+
+function quoteBlock(text) {
+  if (!text) return "> (no text content)";
+  const sanitized = text.replace(/\r/g, "\n");
+  const lines = sanitized.split(/\n/).map(line => `> ${line}`);
+  return lines.join("\n");
+}
+
+function truncate(text, limit) {
+  if (!text) return "";
+  return text.length > limit ? `${text.slice(0, limit - 1)}…` : text;
+}
+
+async function resolveStaffChannel(guild, cms, preferredKey, fallbackId) {
+  if (!guild || !cms) return null;
+  const seen = new Set();
+  const tryFetch = async (id) => {
+    if (!id || seen.has(id)) return null;
+    seen.add(id);
+    const cached = guild.channels.cache.get(id);
+    if (cached?.isTextBased?.()) return cached;
+    try {
+      const fetched = await guild.channels.fetch(id).catch(() => null);
+      return fetched?.isTextBased?.() ? fetched : null;
+    } catch {
+      return null;
+    }
+  };
+  const keys = [preferredKey].filter(Boolean);
+  for (const key of keys) {
+    try {
+      const mapping = await cms.get(guild.id, key);
+      if (!mapping?.channelId) continue;
+      const channel = await tryFetch(mapping.channelId);
+      if (channel) return channel;
+    } catch {
+      // ignore lookup errors
+    }
+  }
+  if (fallbackId) {
+    const fallbackChannel = await tryFetch(fallbackId);
+    if (fallbackChannel) return fallbackChannel;
+  }
+  return null;
+}
+
+function buildFlagEmbed({ message, author, channelId, attachments, classification, staffNote }) {
+  const embed = new EmbedBuilder()
+    .setColor(classification === "executable" ? 0xff4d4f : 0xffa94d)
+    .setTitle(classification === "executable" ? "Executable upload blocked" : "Archive upload flagged")
+    .addFields(
+      { name: "User", value: `${author} (${author.tag})`, inline: false },
+      { name: "Channel", value: `<#${channelId}>`, inline: false },
+      { name: "Message ID", value: message.id, inline: false }
+    );
+
+  const attachmentLines = attachments.map(att => `• ${att.attachment.name || "(unnamed)"} — ${att.classification.label || att.classification.kind}`);
+  const attachmentText = truncate(attachmentLines.join("\n") || "(none)", MAX_EMBED_FIELD);
+  embed.addFields({ name: "Attachments", value: attachmentText, inline: false });
+
+  const quoted = truncate(quoteBlock(message.content || ""), MAX_EMBED_FIELD);
+  embed.addFields({ name: "Message", value: quoted || "> (no text content)", inline: false });
+
+  if (staffNote) {
+    embed.addFields({ name: "Notes", value: truncate(staffNote, MAX_EMBED_FIELD), inline: false });
+  }
+
+  return embed;
+}
+
+function summarizeVirusTotal(result) {
+  if (!result) return null;
+  if (result.error) {
+    return { text: `• **${result.name}** — ${result.error}` };
+  }
+  const stats = result.stats || {};
+  const parts = [
+    `harmless: ${stats.harmless ?? 0}`,
+    `undetected: ${stats.undetected ?? 0}`,
+    `suspicious: ${stats.suspicious ?? 0}`,
+    `malicious: ${stats.malicious ?? 0}`
+  ];
+  const base = `• **${result.name}** — ${parts.join(" | ")}`;
+  const link = result.link ? ` — ${result.link}` : "";
+  return { text: `${base}${link}`.trim(), score: (stats.suspicious ?? 0) + (stats.malicious ?? 0) };
+}
+
+export default {
+  name: "messageCreate",
+  once: false,
+  async execute(message) {
+    try {
+      if (!message?.inGuild?.() || message.author?.bot) return;
+      const fileScannerCfg = CONFIG.fileScanner || {};
+      if (!fileScannerCfg.enabled) return;
+      if (!message.attachments?.size) return;
+
+      if (message.partial) {
+        try {
+          await message.fetch();
+        } catch {
+          // ignore fetch errors; continue with partial data
+        }
+      }
+
+      if (!message.attachments?.size) return;
+
+      const container = message.client?.container;
+      if (!container) return;
+
+      const logger = container.get(TOKENS.Logger);
+      const cms = container.get(TOKENS.ChannelMapService);
+      const vtService = container.get(TOKENS.VirusTotalService);
+
+      const attachments = Array.from(message.attachments.values());
+      if (!attachments.length) return;
+
+      const prefixBytes = Math.max(1, Number(fileScannerCfg.prefixBytes) || 512);
+      const scanned = [];
+      for (const attachment of attachments) {
+        const prefix = await fetchPrefix(attachment.url, prefixBytes, logger, attachment.name);
+        const classification = classifyBytes(prefix);
+        scanned.push({ attachment, prefix, classification });
+      }
+
+      const executableHits = scanned.filter((entry) => entry.classification.kind === "executable");
+      const archiveHits = scanned.filter((entry) => entry.classification.kind === "archive");
+      if (!executableHits.length && !archiveHits.length) return;
+
+      const staffFlagChannel = await resolveStaffChannel(
+        message.guild,
+        cms,
+        fileScannerCfg.staffFlagChannelKey,
+        CONFIG.modLogChannelId
+      );
+
+      const staffActionChannel = await resolveStaffChannel(
+        message.guild,
+        cms,
+        fileScannerCfg.staffActionChannelKey,
+        CONFIG.modLogChannelId
+      );
+
+      const flaggedEntries = [...executableHits, ...archiveHits];
+      if (!flaggedEntries.length) return;
+      let messageDeleted = false;
+
+      if (executableHits.length) {
+        try {
+          await message.delete();
+          messageDeleted = true;
+        } catch (error) {
+          logger?.warn?.("file_scanner.delete_failed", {
+            messageId: message.id,
+            guildId: message.guildId,
+            error: String(error?.message || error)
+          });
+        }
+
+        if (message.channel?.isTextBased?.()) {
+          try {
+            await message.channel.send({
+              content: `⚠️ <@${message.author.id}>, please do not upload executable files. The attachment has been removed.`
+            });
+          } catch (error) {
+            logger?.warn?.("file_scanner.warn_failed", {
+              messageId: message.id,
+              guildId: message.guildId,
+              error: String(error?.message || error)
+            });
+          }
+        }
+      }
+
+      if (staffFlagChannel) {
+        const staffNote = executableHits.length && archiveHits.length
+          ? "Attachments matched executable and archive file signatures."
+          : (executableHits.length
+            ? "Attachments matched executable file signatures."
+            : "Attachments matched archive file signatures.");
+        const embed = buildFlagEmbed({
+          message,
+          author: message.author,
+          channelId: message.channelId,
+          attachments: flaggedEntries,
+          classification: executableHits.length ? "executable" : "archive",
+          staffNote
+        });
+        try {
+          await staffFlagChannel.send({ embeds: [embed] });
+        } catch (error) {
+          logger?.warn?.("file_scanner.flag_failed", {
+            messageId: message.id,
+            guildId: message.guildId,
+            error: String(error?.message || error)
+          });
+        }
+      } else {
+        logger?.warn?.("file_scanner.flag_channel_missing", {
+          guildId: message.guildId,
+          key: fileScannerCfg.staffFlagChannelKey
+        });
+      }
+
+      const vtSummaries = [];
+      const toScan = flaggedEntries.map((entry) => ({
+        attachment: entry.attachment,
+        name: entry.attachment.name || "attachment",
+        url: entry.attachment.url,
+        size: entry.attachment.size || 0
+      }));
+
+      let thresholdTriggered = false;
+      let highestScore = 0;
+      let thresholdLink = null;
+      const vtThreshold = Number(fileScannerCfg.vtActionThreshold) || 0;
+
+      if (toScan.length) {
+        if (vtService?.enabled) {
+          for (const item of toScan) {
+            const vtResult = await vtService.submitFileFromUrl({
+              url: item.url,
+              filename: item.name,
+              size: item.size
+            });
+            if (vtResult.submitted && vtResult.analysis) {
+              const { stats, link } = vtResult.analysis;
+              const summary = summarizeVirusTotal({
+                name: item.name,
+                stats,
+                link
+              });
+              if (summary) {
+                vtSummaries.push(summary.text);
+                if (summary.score >= vtThreshold && vtThreshold > 0) {
+                  thresholdTriggered = true;
+                  if (summary.score > highestScore) {
+                    highestScore = summary.score;
+                    thresholdLink = link || null;
+                  }
+                }
+              }
+            } else {
+              vtSummaries.push(`• **${item.name}** — ${vtResult.error || "VirusTotal submission failed"}`);
+            }
+          }
+        } else {
+          for (const item of toScan) {
+            vtSummaries.push(`• **${item.name}** — VirusTotal not configured (no API key).`);
+          }
+        }
+      }
+
+      if (vtSummaries.length && staffFlagChannel) {
+        const content = [`**VirusTotal summary:**`, ...vtSummaries].join("\n");
+        try {
+          await staffFlagChannel.send({ content });
+        } catch (error) {
+          logger?.warn?.("file_scanner.vt_summary_failed", {
+            messageId: message.id,
+            guildId: message.guildId,
+            error: String(error?.message || error)
+          });
+        }
+      }
+
+      if (thresholdTriggered) {
+        if (!messageDeleted) {
+          try {
+            await message.delete();
+            messageDeleted = true;
+          } catch (error) {
+            logger?.warn?.("file_scanner.delete_failed_threshold", {
+              messageId: message.id,
+              guildId: message.guildId,
+              error: String(error?.message || error)
+            });
+          }
+        }
+
+        const durationMs = Math.max(0, Number(fileScannerCfg.vtMuteDurationMs) || 0);
+        let muteResult = "not_attempted";
+        if (durationMs > 0) {
+          const member = message.member || await message.guild.members.fetch(message.author.id).catch(() => null);
+          if (member?.moderatable) {
+            try {
+              await member.timeout(durationMs, "Automatic action: VirusTotal flagged attachment as high risk");
+              muteResult = "muted";
+            } catch (error) {
+              muteResult = `failed: ${String(error?.message || error)}`;
+              logger?.error?.("file_scanner.auto_mute_failed", {
+                guildId: message.guildId,
+                userId: message.author.id,
+                error: String(error?.message || error)
+              });
+            }
+          } else {
+            muteResult = "not_moderatable";
+            logger?.warn?.("file_scanner.auto_mute_unavailable", {
+              guildId: message.guildId,
+              userId: message.author.id
+            });
+          }
+        }
+
+        if (staffActionChannel) {
+          const durationText = durationMs > 0 ? formatDuration(durationMs) : "0s";
+          const actionLines = [
+            `⛔️ **Automatic high-risk upload action**`,
+            `User: <@${message.author.id}> (${message.author.tag})`,
+            `Score: ${highestScore} (suspicious + malicious)`,
+            `Mute: ${muteResult === "muted" ? `applied for ${durationText}` : muteResult.replace(/_/g, " ")}`,
+            thresholdLink ? `Report: ${thresholdLink}` : null
+          ].filter(Boolean);
+          try {
+            await staffActionChannel.send({ content: actionLines.join("\n") });
+          } catch (error) {
+            logger?.warn?.("file_scanner.action_notify_failed", {
+              guildId: message.guildId,
+              error: String(error?.message || error)
+            });
+          }
+        }
+      }
+    } catch (error) {
+      try {
+        const container = message?.client?.container;
+        const logger = container?.get?.(TOKENS.Logger);
+        logger?.error?.("file_scanner.unhandled_error", {
+          messageId: message?.id,
+          guildId: message?.guildId,
+          error: String(error?.message || error)
+        });
+      } catch {
+        // ignore logging errors
+      }
+    }
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import { Logger } from "./utils/logger.js";
 import mongoose from "mongoose";
 import { ModerationLogService } from "./services/ModerationLogService.js";
 import { RuntimeModerationState } from "./services/RuntimeModerationState.js";
+import { VirusTotalService } from "./services/VirusTotalService.js";
 
 async function main() {
   await connectMongo();
@@ -39,6 +40,7 @@ async function main() {
   container.set(TOKENS.StaffRoleService, new StaffRoleService());
   container.set(TOKENS.AntiSpamService, new AntiSpamService(CONFIG.antiSpam));
   container.set(TOKENS.RuntimeModerationState, new RuntimeModerationState());
+  container.set(TOKENS.VirusTotalService, new VirusTotalService(CONFIG.fileScanner?.virusTotal || {}, logger));
 
   // Plugins
   const pluginDirs = (CONFIG.privateModuleDirs || []).map(p => resolve(process.cwd(), p));

--- a/src/services/VirusTotalService.js
+++ b/src/services/VirusTotalService.js
@@ -1,0 +1,125 @@
+import { setTimeout as wait } from "node:timers/promises";
+
+const API_BASE = "https://www.virustotal.com/api/v3";
+
+function ensurePositiveInt(value, fallback) {
+  const num = Number(value);
+  return Number.isFinite(num) && num > 0 ? Math.floor(num) : fallback;
+}
+
+export class VirusTotalService {
+  #apiKey;
+  #pollIntervalMs;
+  #maxPolls;
+  #maxFileBytes;
+  #logger;
+
+  constructor(options = {}, logger = null) {
+    this.#apiKey = options.apiKey || "";
+    this.#pollIntervalMs = ensurePositiveInt(options.pollIntervalMs, 5000);
+    this.#maxPolls = ensurePositiveInt(options.maxPolls, 12);
+    this.#maxFileBytes = ensurePositiveInt(options.maxFileBytes, 32 * 1024 * 1024);
+    this.#logger = logger;
+  }
+
+  get enabled() {
+    return Boolean(this.#apiKey);
+  }
+
+  get maxFileBytes() {
+    return this.#maxFileBytes;
+  }
+
+  async submitFileFromUrl({ url, filename = "attachment", size = 0 }) {
+    if (!this.enabled) {
+      return { submitted: false, error: "VirusTotal API key not configured." };
+    }
+    if (!url) {
+      return { submitted: false, error: "Missing attachment URL." };
+    }
+    if (this.#maxFileBytes && size && size > this.#maxFileBytes) {
+      const errMsg = `Attachment exceeds VirusTotal upload limit (${size} > ${this.#maxFileBytes}).`;
+      this.#logger?.warn?.("virustotal.file_too_large", { filename, size, limit: this.#maxFileBytes });
+      return { submitted: false, error: errMsg };
+    }
+
+    try {
+      const downloadRes = await fetch(url);
+      if (!downloadRes.ok) {
+        throw new Error(`Download failed with status ${downloadRes.status}`);
+      }
+      const arrayBuffer = await downloadRes.arrayBuffer();
+      if (this.#maxFileBytes && arrayBuffer.byteLength > this.#maxFileBytes) {
+        const errMsg = `Attachment exceeds VirusTotal upload limit after download (${arrayBuffer.byteLength} > ${this.#maxFileBytes}).`;
+        this.#logger?.warn?.("virustotal.file_too_large_post_download", { filename, size: arrayBuffer.byteLength, limit: this.#maxFileBytes });
+        return { submitted: false, error: errMsg };
+      }
+
+      const blob = new Blob([arrayBuffer]);
+      const form = new FormData();
+      form.append("file", blob, filename);
+
+      const uploadRes = await fetch(`${API_BASE}/files`, {
+        method: "POST",
+        headers: { "x-apikey": this.#apiKey },
+        body: form
+      });
+
+      if (!uploadRes.ok) {
+        const text = await uploadRes.text().catch(() => "");
+        throw new Error(`VirusTotal upload failed (${uploadRes.status}): ${text || "no body"}`);
+      }
+
+      const uploadJson = await uploadRes.json().catch(() => null);
+      const analysisId = uploadJson?.data?.id;
+      if (!analysisId) {
+        throw new Error("VirusTotal response missing analysis id");
+      }
+
+      const analysis = await this.#pollAnalysis(analysisId);
+      return { submitted: true, analysisId, analysis };
+    } catch (error) {
+      this.#logger?.error?.("virustotal.submit_failed", {
+        filename,
+        error: String(error?.message || error)
+      });
+      return { submitted: false, error: String(error?.message || error) };
+    }
+  }
+
+  async #pollAnalysis(id) {
+    let lastError = null;
+    for (let attempt = 0; attempt < this.#maxPolls; attempt += 1) {
+      try {
+        const res = await fetch(`${API_BASE}/analyses/${id}`, {
+          headers: { "x-apikey": this.#apiKey }
+        });
+        if (!res.ok) {
+          const body = await res.text().catch(() => "");
+          throw new Error(`Analysis fetch failed (${res.status}): ${body || "no body"}`);
+        }
+        const json = await res.json().catch(() => null);
+        const status = json?.data?.attributes?.status;
+        if (status === "completed") {
+          const stats = json?.data?.attributes?.stats || {};
+          const fileHash = json?.meta?.file_info?.sha256 || json?.data?.id || null;
+          const link = fileHash ? `https://www.virustotal.com/gui/file/${fileHash}` : null;
+          return { status, stats, link, raw: json };
+        }
+        lastError = null;
+      } catch (error) {
+        lastError = error;
+        this.#logger?.warn?.("virustotal.poll_failed", {
+          analysisId: id,
+          attempt: attempt + 1,
+          error: String(error?.message || error)
+        });
+      }
+      await wait(this.#pollIntervalMs);
+    }
+    if (lastError) {
+      throw lastError;
+    }
+    throw new Error("VirusTotal analysis polling timed out");
+  }
+}


### PR DESCRIPTION
## Summary
- add configuration and a VirusTotal service to support file scanning
- block executable uploads, warn users, and flag messages with staff context embeds
- submit flagged files to VirusTotal, escalate suspicious results, and auto-mute on high scores

## Testing
- npm run check:commands

------
https://chatgpt.com/codex/tasks/task_e_68e20478a4d8832b8d8908673644272c