### PR TITLE
feat: add admin emoji import commands

### DIFF
--- a/src/commands/admin/add-emojis-url.js
+++ b/src/commands/admin/add-emojis-url.js
@@ -1,0 +1,69 @@
+import { MessageFlags, PermissionFlagsBits, SlashCommandBuilder } from "discord.js";
+import { fetchExistingEmojiNames, ensureBotEmojiPermissions, createEmojiFromUrl, isValidEmojiName } from "../../utils/emojiImporter.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("add-emojis-url")
+    .setDescription("Add a single custom emoji from a direct image URL")
+    .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
+    .addStringOption(option =>
+      option
+        .setName("name")
+        .setDescription("Name to assign to the emoji")
+        .setRequired(true)
+        .setMaxLength(32))
+    .addStringOption(option =>
+      option
+        .setName("url")
+        .setDescription("Direct image URL")
+        .setRequired(true)
+        .setMaxLength(400))
+    .setDMPermission(false),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: "Guild only." });
+    }
+
+    const name = interaction.options.getString("name", true).trim();
+    const url = interaction.options.getString("url", true).trim();
+
+    if (!isValidEmojiName(name)) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: "Emoji name must be 2-32 characters (letters, numbers, underscores)." });
+    }
+
+    if (!/^https?:\/\//i.test(url)) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: "URL must start with http:// or https://" });
+    }
+
+    try {
+      await ensureBotEmojiPermissions(interaction);
+    } catch (error) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: error.message ?? "Missing permissions" });
+    }
+
+    try {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      const usedNames = await fetchExistingEmojiNames(interaction.guild);
+      const reason = `Emoji import via /${interaction.commandName} by ${interaction.user.tag ?? interaction.user.username}`;
+
+      await createEmojiFromUrl(interaction.guild, name, url, usedNames, reason);
+
+      await interaction.editReply({ content: "Done" });
+    } catch (error) {
+      const message = error?.message ?? "Failed to add emoji";
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: `Error: ${message}` });
+      } else {
+        await interaction.reply({ flags: MessageFlags.Ephemeral, content: `Error: ${message}` });
+      }
+    }
+  },
+  meta: {
+    category: "admin",
+    description: "Upload a custom emoji to this guild from a direct image URL.",
+    usage: "/add-emojis-url name:<name> url:<image url>",
+    examples: ["/add-emojis-url name:party url:https://example.com/party.png"],
+    permissions: "Ban Members"
+  }
+};

--- a/src/commands/admin/steal-emojis-message-url.js
+++ b/src/commands/admin/steal-emojis-message-url.js
@@ -1,0 +1,85 @@
+import { MessageFlags, PermissionFlagsBits, SlashCommandBuilder } from "discord.js";
+import { extractCustomEmojis, fetchExistingEmojiNames, ensureBotEmojiPermissions, createEmojiFromCdn } from "../../utils/emojiImporter.js";
+
+const MESSAGE_URL_REGEX = /^https?:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/channels\/(\d{17,20}|@me)\/(\d{17,20})\/(\d{17,20})$/;
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("steal-emojis-message-url")
+    .setDescription("Import custom emojis from a message link in this server")
+    .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
+    .addStringOption(option =>
+      option
+        .setName("url")
+        .setDescription("Link to a message containing custom emojis")
+        .setRequired(true)
+        .setMaxLength(200))
+    .setDMPermission(false),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: "Guild only." });
+    }
+
+    const url = interaction.options.getString("url", true).trim();
+    const match = MESSAGE_URL_REGEX.exec(url);
+
+    if (!match) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: "Invalid message URL." });
+    }
+
+    const [ , guildId, channelId, messageId ] = match;
+    if (guildId !== interaction.guildId) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: "Message must be from this server." });
+    }
+
+    try {
+      await ensureBotEmojiPermissions(interaction);
+    } catch (error) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: error.message ?? "Missing permissions" });
+    }
+
+    let message;
+    try {
+      const channel = await interaction.client.channels.fetch(channelId);
+      if (!channel || channel.guildId !== interaction.guildId || !channel.isTextBased?.()) {
+        return interaction.reply({ flags: MessageFlags.Ephemeral, content: "Cannot access that message." });
+      }
+
+      message = await channel.messages.fetch(messageId);
+    } catch (error) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: "Failed to fetch message." });
+    }
+
+    const emojiMentions = extractCustomEmojis(message?.content ?? "");
+    if (!emojiMentions.length) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: "No emojis" });
+    }
+
+    try {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      const usedNames = await fetchExistingEmojiNames(interaction.guild);
+      const reason = `Emoji import via /${interaction.commandName} by ${interaction.user.tag ?? interaction.user.username}`;
+
+      for (const emoji of emojiMentions) {
+        await createEmojiFromCdn(interaction.guild, emoji, usedNames, reason);
+      }
+
+      await interaction.editReply({ content: "Done" });
+    } catch (error) {
+      const messageText = error?.message ?? "Failed to import emojis";
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: `Error: ${messageText}` });
+      } else {
+        await interaction.reply({ flags: MessageFlags.Ephemeral, content: `Error: ${messageText}` });
+      }
+    }
+  },
+  meta: {
+    category: "admin",
+    description: "Import custom emojis from a message link in this guild.",
+    usage: "/steal-emojis-message-url url:<message link>",
+    examples: ["/steal-emojis-message-url url:https://discord.com/channels/..."],
+    permissions: "Ban Members"
+  }
+};

--- a/src/commands/admin/steal-emojis.js
+++ b/src/commands/admin/steal-emojis.js
@@ -1,0 +1,60 @@
+import { MessageFlags, PermissionFlagsBits, SlashCommandBuilder } from "discord.js";
+import { extractCustomEmojis, fetchExistingEmojiNames, ensureBotEmojiPermissions, createEmojiFromCdn } from "../../utils/emojiImporter.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("steal-emojis")
+    .setDescription("Import custom emojis from provided text")
+    .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers)
+    .addStringOption(option =>
+      option
+        .setName("text")
+        .setDescription("Text containing custom emoji mentions")
+        .setRequired(true)
+        .setMaxLength(4000))
+    .setDMPermission(false),
+  async execute(interaction) {
+    if (!interaction.inGuild()) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: "Guild only." });
+    }
+
+    const text = interaction.options.getString("text", true);
+    const emojiMentions = extractCustomEmojis(text);
+    if (!emojiMentions.length) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: "No emojis" });
+    }
+
+    try {
+      await ensureBotEmojiPermissions(interaction);
+    } catch (error) {
+      return interaction.reply({ flags: MessageFlags.Ephemeral, content: error.message ?? "Missing permissions" });
+    }
+
+    try {
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
+      const usedNames = await fetchExistingEmojiNames(interaction.guild);
+      const reason = `Emoji import via /${interaction.commandName} by ${interaction.user.tag ?? interaction.user.username}`;
+
+      for (const emoji of emojiMentions) {
+        await createEmojiFromCdn(interaction.guild, emoji, usedNames, reason);
+      }
+
+      await interaction.editReply({ content: "Done" });
+    } catch (error) {
+      const message = error?.message ?? "Failed to import emojis";
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: `Error: ${message}` });
+      } else {
+        await interaction.reply({ flags: MessageFlags.Ephemeral, content: `Error: ${message}` });
+      }
+    }
+  },
+  meta: {
+    category: "admin",
+    description: "Import custom emojis from a block of text.",
+    usage: "/steal-emojis text:<message text>",
+    examples: ["/steal-emojis text:<:smile:123>"],
+    permissions: "Ban Members"
+  }
+};

--- a/src/utils/emojiImporter.js
+++ b/src/utils/emojiImporter.js
@@ -1,0 +1,122 @@
+import { PermissionFlagsBits } from "discord.js";
+
+const CUSTOM_EMOJI_REGEX = /<(?<animated>a?):(?<name>[a-zA-Z0-9_]{2,32}):(?<id>\d{17,20})>/g;
+
+export function extractCustomEmojis(text) {
+  if (!text) return [];
+  const results = [];
+  const regex = new RegExp(CUSTOM_EMOJI_REGEX.source, "g");
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    const groups = match.groups ?? {};
+    results.push({
+      animated: groups.animated === "a",
+      originalName: groups.name,
+      id: groups.id
+    });
+  }
+  return results;
+}
+
+export function getEmojiCdnUrl({ id, animated }) {
+  const extension = animated ? "gif" : "png";
+  return `https://cdn.discordapp.com/emojis/${id}.${extension}`;
+}
+
+export function sanitizeEmojiName(name) {
+  if (!name) return "emoji";
+  let sanitized = name.replace(/[^a-zA-Z0-9_]/g, "_");
+  if (sanitized.length < 2) sanitized = sanitized.padEnd(2, "_");
+  if (sanitized.length > 32) sanitized = sanitized.slice(0, 32);
+  return sanitized;
+}
+
+export function isValidEmojiName(name) {
+  return typeof name === "string" && /^[a-zA-Z0-9_]{2,32}$/.test(name);
+}
+
+export function ensureUniqueEmojiName(baseName, usedNames) {
+  let base = sanitizeEmojiName(baseName);
+  if (!usedNames.has(base)) {
+    usedNames.add(base);
+    return base;
+  }
+
+  let counter = 0;
+  while (counter < 1000) {
+    const suffix = `_${counter}`;
+    const trimmedBase = base.slice(0, Math.max(2, 32 - suffix.length));
+    const candidate = `${trimmedBase}${suffix}`;
+    if (!usedNames.has(candidate)) {
+      usedNames.add(candidate);
+      return candidate;
+    }
+    counter += 1;
+  }
+
+  throw new Error("Unable to generate unique emoji name");
+}
+
+export async function fetchExistingEmojiNames(guild) {
+  const collection = await guild.emojis.fetch();
+  const names = new Set();
+  for (const emoji of collection.values()) {
+    if (emoji.name) names.add(emoji.name);
+  }
+  return names;
+}
+
+export async function ensureBotEmojiPermissions(interaction) {
+  const me = interaction.guild?.members?.me;
+  if (!me?.permissions?.has(PermissionFlagsBits.ManageGuildExpressions)) {
+    throw new Error("Bot requires the Manage Emojis and Stickers permission.");
+  }
+}
+
+function resolveExtensionFromContentType(contentType) {
+  const match = /image\/([a-zA-Z0-9.+-]+)/.exec(contentType ?? "");
+  if (!match) return null;
+  const subtype = match[1].toLowerCase();
+  if (subtype === "jpeg") return "jpg";
+  if (subtype.includes("gif")) return "gif";
+  if (subtype.includes("png")) return "png";
+  if (subtype.includes("webp")) return "webp";
+  return subtype;
+}
+
+export async function fetchEmojiAttachment(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch emoji asset (${response.status})`);
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (!contentType?.startsWith("image/")) {
+    throw new Error("Emoji URL did not return an image.");
+  }
+
+  const buffer = Buffer.from(await response.arrayBuffer());
+  if (!buffer.length) {
+    throw new Error("Emoji download returned empty data.");
+  }
+  const extension = resolveExtensionFromContentType(contentType);
+  return { buffer, contentType, extension };
+}
+
+export async function createEmojiFromCdn(guild, emoji, usedNames, reason) {
+  const url = getEmojiCdnUrl(emoji);
+  const { buffer, extension } = await fetchEmojiAttachment(url);
+  const name = ensureUniqueEmojiName(emoji.originalName, usedNames);
+  const ext = extension ?? (emoji.animated ? "gif" : "png");
+  const filename = `${name}.${ext}`;
+  await guild.emojis.create({ attachment: { attachment: buffer, name: filename }, name, reason });
+  return name;
+}
+
+export async function createEmojiFromUrl(guild, name, url, usedNames, reason) {
+  const { buffer, extension } = await fetchEmojiAttachment(url);
+  const uniqueName = ensureUniqueEmojiName(name, usedNames);
+  const filename = extension ? `${uniqueName}.${extension}` : uniqueName;
+  await guild.emojis.create({ attachment: { attachment: buffer, name: filename }, name: uniqueName, reason });
+  return uniqueName;
+}


### PR DESCRIPTION
## Summary
- add admin slash commands to steal emojis from text or message URLs and to add one from a direct image link
- share emoji importer utilities to parse mentions, enforce unique names, and upload assets with permission checks

## Testing
- npm run check:commands

------
https://chatgpt.com/codex/tasks/task_e_68e206a89154832b82ea83843295ba4c