### PR TITLE
Add staff member lifecycle logging

### DIFF
--- a/default.configs.json
+++ b/default.configs.json
@@ -7,10 +7,18 @@
   "mongo": { "uri": "mongodb://localhost:27017/discord_modbot" },
   "privateModuleDirs": ["modules/bot-private"],
   "modLogChannelId": "123456789012345678",
+  "channels": {
+    "staff_member_log": "123456789012345678"
+  },
   "brandNew": {
     "enabled": true,
     "thresholdMs": 1800000,
     "alertChannelId": "123456789012345678"
+  },
+  "colors": {
+    "green": "0x57F287",
+    "red": "0xED4245",
+    "default": "0x5865F2"
   },
   "antiSpam": {
     "msgWindowMs": 15000,

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,8 @@ import { join } from "node:path";
 
 const cfgPath = join(process.cwd(), "configs.json");
 const fileCfg = existsSync(cfgPath) ? JSON.parse(readFileSync(cfgPath, "utf8")) : {};
+const channelsFileCfg = fileCfg?.channels || {};
+const colorsFileCfg = fileCfg?.colors || {};
 
 const envOr = (name, fallback) => {
   const v = process.env[name];
@@ -18,6 +20,24 @@ const toNumber = (v, fallback) => {
   if (v === undefined || v === null || v === "") return fallback;
   const n = Number(v);
   return Number.isFinite(n) ? n : fallback;
+};
+
+const parseColor = (value, fallback) => {
+  if (value === undefined || value === null || value === "") return fallback;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const str = String(value).trim();
+  if (!str) return fallback;
+  const lower = str.toLowerCase();
+  if (lower.startsWith("0x")) {
+    const parsed = Number.parseInt(lower.slice(2), 16);
+    return Number.isNaN(parsed) ? fallback : parsed;
+  }
+  if (str.startsWith("#")) {
+    const parsed = Number.parseInt(str.slice(1), 16);
+    return Number.isNaN(parsed) ? fallback : parsed;
+  }
+  const parsed = Number(str);
+  return Number.isFinite(parsed) ? parsed : fallback;
 };
 
 const toBoolean = (v, fallback) => {
@@ -42,6 +62,11 @@ const brandNewDefaults = {
   alertChannelId: ""
 };
 const brandNewFileCfg = fileCfg?.brandNew || {};
+const colorDefaults = {
+  green: 0x57F287,
+  red: 0xED4245,
+  neutral: 0x5865F2
+};
 
 export const CONFIG = {
   token: envOr("DISCORD_TOKEN", fileCfg?.discord?.token || ""),
@@ -52,6 +77,9 @@ export const CONFIG = {
   modLogChannelId: envOr("MOD_LOG_CHANNEL_ID", fileCfg?.modLogChannelId || ""),
   logLevel: envOr("LOG_LEVEL", "info"),
   debugChannelId: envOr("DEBUG_CHANNEL_ID", ""),
+  channels: {
+    staffMemberLogId: envOr("STAFF_MEMBER_LOG_CHANNEL_ID", channelsFileCfg.staff_member_log ?? channelsFileCfg.staffMemberLogId ?? "")
+  },
   antiSpam: {
     msgWindowMs: toNumber(envOr("ANTISPAM_MSG_WINDOW_MS", antiSpamFileCfg.msgWindowMs ?? antiSpamDefaults.msgWindowMs), antiSpamDefaults.msgWindowMs),
     msgMaxInWindow: toNumber(envOr("ANTISPAM_MSG_MAX", antiSpamFileCfg.msgMaxInWindow ?? antiSpamDefaults.msgMaxInWindow), antiSpamDefaults.msgMaxInWindow),
@@ -62,6 +90,11 @@ export const CONFIG = {
     enabled: toBoolean(envOr("BRAND_NEW_ENABLED", brandNewFileCfg.enabled ?? brandNewDefaults.enabled), brandNewDefaults.enabled),
     thresholdMs: toNumber(envOr("BRAND_NEW_THRESHOLD_MS", brandNewFileCfg.thresholdMs ?? brandNewDefaults.thresholdMs), brandNewDefaults.thresholdMs),
     alertChannelId: envOr("BRAND_NEW_ALERT_CHANNEL_ID", brandNewFileCfg.alertChannelId ?? brandNewDefaults.alertChannelId) || ""
+  },
+  colors: {
+    green: parseColor(envOr("COLOR_GREEN", colorsFileCfg.green ?? colorDefaults.green), colorDefaults.green),
+    red: parseColor(envOr("COLOR_RED", colorsFileCfg.red ?? colorDefaults.red), colorDefaults.red),
+    neutral: parseColor(envOr("COLOR_DEFAULT", colorsFileCfg.default ?? colorsFileCfg.neutral ?? colorDefaults.neutral), colorDefaults.neutral)
   }
 };
 

--- a/src/container.js
+++ b/src/container.js
@@ -15,6 +15,7 @@ export const TOKENS = {
   ModerationLogService: "ModerationLogService",
   ChannelMapService: "ChannelMapService",
   StaffRoleService: "StaffRoleService",
+  StaffMemberLogService: "StaffMemberLogService",
   AntiSpamService: "AntiSpamService",
   RuntimeModerationState: "RuntimeModerationState"
 };

--- a/src/events/guildMemberAdd.staffLog.js
+++ b/src/events/guildMemberAdd.staffLog.js
@@ -1,0 +1,49 @@
+import { formatDuration } from "../utils/time.js";
+import { getMemberLogColors } from "../utils/memberLog.js";
+import { createMemberEmbedBase } from "../utils/memberLogEmbeds.js";
+import { formatMemberLine, getLogger, getStaffMemberLogService } from "./memberLogShared.js";
+import { safeTimestamp } from "../utils/discordUsers.js";
+
+const COLORS = getMemberLogColors();
+
+export default {
+  name: "guildMemberAdd",
+  once: false,
+  async execute(member) {
+    if (!member?.client?.container || !member.guild) return;
+
+    const logService = getStaffMemberLogService(member.client.container);
+    if (!logService) return;
+
+    try {
+      const { embed, user } = createMemberEmbedBase({
+        member,
+        title: "Member Joined",
+        color: COLORS.join
+      });
+
+      const lines = [
+        `Member: ${formatMemberLine(member, user)}`
+      ];
+
+      const created = safeTimestamp(user?.createdTimestamp ?? user?.createdAt);
+      if (created !== null) {
+        const ageMs = Math.max(0, Date.now() - created);
+        lines.push(`Account Age: ${formatDuration(ageMs)}`);
+      }
+
+      embed.setDescription(lines.join("\n"));
+
+      await logService.send(member.guild, { embeds: [embed] });
+    } catch (err) {
+      const logger = getLogger(member.client.container);
+      if (logger?.error) {
+        await logger.error("staffMemberLog.join.error", {
+          guildId: member.guild.id,
+          userId: member.id,
+          error: err instanceof Error ? err.stack : String(err)
+        }).catch(() => {});
+      }
+    }
+  }
+};

--- a/src/events/guildMemberRemove.staffLog.js
+++ b/src/events/guildMemberRemove.staffLog.js
@@ -1,0 +1,49 @@
+import { getMemberLogColors } from "../utils/memberLog.js";
+import { createMemberEmbedBase } from "../utils/memberLogEmbeds.js";
+import { formatMemberLine, getLogger, getStaffMemberLogService } from "./memberLogShared.js";
+
+const COLORS = getMemberLogColors();
+
+async function resolveUser(member) {
+  if (member?.user) return member.user;
+  if (member?.id && member?.client?.users?.fetch) {
+    try {
+      return await member.client.users.fetch(member.id);
+    } catch {/* ignore fetch errors */}
+  }
+  return null;
+}
+
+export default {
+  name: "guildMemberRemove",
+  once: false,
+  async execute(member) {
+    if (!member?.client?.container || !member.guild) return;
+
+    const logService = getStaffMemberLogService(member.client.container);
+    if (!logService) return;
+
+    try {
+      const fallbackUser = await resolveUser(member);
+      const { embed, user } = createMemberEmbedBase({
+        member,
+        user: fallbackUser,
+        title: "Member Left",
+        color: COLORS.leave
+      });
+
+      embed.setDescription(`Member: ${formatMemberLine(member, user)}`);
+
+      await logService.send(member.guild, { embeds: [embed] });
+    } catch (err) {
+      const logger = getLogger(member.client.container);
+      if (logger?.error) {
+        await logger.error("staffMemberLog.leave.error", {
+          guildId: member.guild.id,
+          userId: member.id ?? null,
+          error: err instanceof Error ? err.stack : String(err)
+        }).catch(() => {});
+      }
+    }
+  }
+};

--- a/src/events/guildMemberUpdate.staffLog.js
+++ b/src/events/guildMemberUpdate.staffLog.js
@@ -1,0 +1,105 @@
+import { getMemberLogColors } from "../utils/memberLog.js";
+import { createMemberEmbedBase } from "../utils/memberLogEmbeds.js";
+import { formatMemberLine, getLogger, getStaffMemberLogService } from "./memberLogShared.js";
+
+const COLORS = getMemberLogColors();
+const MAX_ROLE_LINES = 10;
+
+function normalizeDisplayName(member) {
+  return member?.displayName ?? member?.nickname ?? member?.user?.globalName ?? member?.user?.username ?? null;
+}
+
+function computeRoleDiff(oldMember, newMember) {
+  const everyoneId = newMember?.guild?.id ?? oldMember?.guild?.id ?? null;
+  const oldIds = new Set();
+  const newIds = new Set();
+
+  if (oldMember?.roles?.cache) {
+    for (const [id] of oldMember.roles.cache) {
+      if (id && id !== everyoneId) oldIds.add(id);
+    }
+  }
+  if (newMember?.roles?.cache) {
+    for (const [id] of newMember.roles.cache) {
+      if (id && id !== everyoneId) newIds.add(id);
+    }
+  }
+
+  const lines = [];
+  for (const id of newIds) {
+    if (!oldIds.has(id)) lines.push(`Added <@&${id}>`);
+  }
+  for (const id of oldIds) {
+    if (!newIds.has(id)) lines.push(`Removed <@&${id}>`);
+  }
+
+  const total = lines.length;
+  if (!total) return { lines: [], total: 0 };
+
+  if (total > MAX_ROLE_LINES) {
+    const shown = lines.slice(0, MAX_ROLE_LINES);
+    shown.push(`…and ${total - MAX_ROLE_LINES} more change(s)`);
+    return { lines: shown, total };
+  }
+
+  return { lines, total };
+}
+
+export default {
+  name: "guildMemberUpdate",
+  once: false,
+  async execute(oldMember, newMember) {
+    const container = newMember?.client?.container;
+    const guild = newMember?.guild ?? oldMember?.guild ?? null;
+    if (!container || !guild) return;
+
+    const logService = getStaffMemberLogService(container);
+    if (!logService) return;
+
+    let currentMember = newMember;
+    if (currentMember?.partial && currentMember.fetch) {
+      try {
+        currentMember = await currentMember.fetch();
+      } catch {/* ignore fetch errors */}
+    }
+
+    const displayNameBefore = normalizeDisplayName(oldMember);
+    const displayNameAfter = normalizeDisplayName(currentMember);
+    const nameChanged = displayNameBefore !== displayNameAfter;
+    const roleDiff = computeRoleDiff(oldMember, currentMember);
+
+    if (!nameChanged && roleDiff.total === 0) return;
+
+    try {
+      const { embed, user } = createMemberEmbedBase({
+        member: currentMember,
+        title: "Member Updated",
+        color: COLORS.neutral
+      });
+
+      const description = [];
+      description.push(`Member: ${formatMemberLine(currentMember, user)}`);
+
+      if (nameChanged) {
+        description.push("", `Old display name: ${displayNameBefore ?? "—"}`, `New display name: ${displayNameAfter ?? "—"}`);
+      }
+
+      if (roleDiff.total > 0) {
+        description.push("", ...roleDiff.lines);
+      }
+
+      embed.setDescription(description.join("\n"));
+
+      await logService.send(guild, { embeds: [embed] });
+    } catch (err) {
+      const logger = getLogger(container);
+      if (logger?.error) {
+        await logger.error("staffMemberLog.update.error", {
+          guildId: guild.id,
+          userId: currentMember?.id ?? null,
+          error: err instanceof Error ? err.stack : String(err)
+        }).catch(() => {});
+      }
+    }
+  }
+};

--- a/src/events/memberLogShared.js
+++ b/src/events/memberLogShared.js
@@ -1,0 +1,20 @@
+import { TOKENS } from "../container.js";
+import { formatUserTag } from "../utils/discordUsers.js";
+
+export function formatMemberLine(member, user) {
+  const resolvedUser = user ?? member?.user ?? null;
+  const id = member?.id ?? resolvedUser?.id ?? null;
+  const mention = id ? `<@${id}>` : "Unknown member";
+  const username = formatUserTag(resolvedUser);
+  return `${mention} (\`${username}\`)`;
+}
+
+export function getLogger(container) {
+  if (!container) return null;
+  try { return container.get(TOKENS.Logger); } catch { return null; }
+}
+
+export function getStaffMemberLogService(container) {
+  if (!container) return null;
+  try { return container.get(TOKENS.StaffMemberLogService); } catch { return null; }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import { Logger } from "./utils/logger.js";
 import mongoose from "mongoose";
 import { ModerationLogService } from "./services/ModerationLogService.js";
 import { RuntimeModerationState } from "./services/RuntimeModerationState.js";
+import { StaffMemberLogService } from "./services/StaffMemberLogService.js";
 
 async function main() {
   await connectMongo();
@@ -35,10 +36,16 @@ async function main() {
   const moderationService = new ModerationService(logger, moderationLogService);
   container.set(TOKENS.ModerationService, moderationService);
 
-  container.set(TOKENS.ChannelMapService, new ChannelMapService());
+  const channelMapService = new ChannelMapService();
+  container.set(TOKENS.ChannelMapService, channelMapService);
   container.set(TOKENS.StaffRoleService, new StaffRoleService());
   container.set(TOKENS.AntiSpamService, new AntiSpamService(CONFIG.antiSpam));
   container.set(TOKENS.RuntimeModerationState, new RuntimeModerationState());
+  container.set(TOKENS.StaffMemberLogService, new StaffMemberLogService({
+    channelMapService,
+    fallbackChannelId: CONFIG.channels?.staffMemberLogId || "",
+    logger
+  }));
 
   // Plugins
   const pluginDirs = (CONFIG.privateModuleDirs || []).map(p => resolve(process.cwd(), p));

--- a/src/services/StaffMemberLogService.js
+++ b/src/services/StaffMemberLogService.js
@@ -1,0 +1,113 @@
+import { Collection } from "discord.js";
+
+const CHANNEL_MAP_KEYS = [
+  "staff_member_log",
+  "member_log",
+  "bot_log",
+  "action_log",
+  "mod_log"
+];
+
+function isTextSendable(channel) {
+  if (!channel?.isTextBased?.()) return false;
+  if (typeof channel.send !== "function") return false;
+  if (channel.isThread?.()) return true;
+  return channel.type === 0 || channel.type === 5 || channel.type === 15 || channel.type === 11 || channel.type === 12;
+}
+
+export class StaffMemberLogService {
+  #missingWarned;
+  #cache;
+
+  constructor({ channelMapService, fallbackChannelId = "", logger } = {}) {
+    this.channelMapService = channelMapService;
+    this.fallbackChannelId = typeof fallbackChannelId === "string" ? fallbackChannelId : "";
+    this.logger = logger;
+    this.#missingWarned = new Set();
+    this.#cache = new Collection();
+  }
+
+  async send(guild, payload) {
+    if (!guild || !payload) return false;
+    try {
+      const channel = await this.#resolveChannel(guild);
+      if (!channel) {
+        this.#logMissing(guild.id);
+        return false;
+      }
+      await channel.send(payload);
+      return true;
+    } catch (err) {
+      this.clearCache(guild?.id);
+      if (this.logger?.error) {
+        await this.logger.error("staffMemberLog.send.failed", {
+          guildId: guild?.id ?? null,
+          error: err instanceof Error ? err.stack : String(err)
+        });
+      }
+      return false;
+    }
+  }
+
+  clearCache(guildId) {
+    if (!guildId) return;
+    this.#cache.delete(guildId);
+    this.#missingWarned.delete(guildId);
+  }
+
+  async #resolveChannel(guild) {
+    const cached = this.#cache.get(guild.id);
+    if (cached?.channel && isTextSendable(cached.channel)) {
+      return cached.channel;
+    }
+
+    const seen = new Set();
+    const tryFetch = async (id) => {
+      if (!id || seen.has(id)) return null;
+      seen.add(id);
+      const fromCache = guild.channels.cache.get(id);
+      if (isTextSendable(fromCache)) return fromCache;
+      const fetched = await guild.channels.fetch(id).catch(() => null);
+      return isTextSendable(fetched) ? fetched : null;
+    };
+
+    if (this.channelMapService) {
+      for (const key of CHANNEL_MAP_KEYS) {
+        try {
+          const mapping = await this.channelMapService.get(guild.id, key);
+          if (!mapping?.channelId) continue;
+          const mapped = await tryFetch(mapping.channelId);
+          if (mapped) {
+            this.#cache.set(guild.id, { channel: mapped, resolvedAt: Date.now() });
+            return mapped;
+          }
+        } catch (err) {
+          if (this.logger?.warn) {
+            await this.logger.warn("staffMemberLog.channelMap.error", {
+              guildId: guild.id,
+              key,
+              error: err instanceof Error ? err.stack : String(err)
+            });
+          }
+        }
+      }
+    }
+
+    const fallback = await tryFetch(this.fallbackChannelId);
+    if (fallback) {
+      this.#cache.set(guild.id, { channel: fallback, resolvedAt: Date.now() });
+      return fallback;
+    }
+
+    this.#cache.delete(guild.id);
+    return null;
+  }
+
+  #logMissing(guildId) {
+    if (!guildId || this.#missingWarned.has(guildId)) return;
+    this.#missingWarned.add(guildId);
+    if (this.logger?.warn) {
+      this.logger.warn("staffMemberLog.missingChannel", { guildId }).catch(() => {});
+    }
+  }
+}

--- a/src/utils/discordUsers.js
+++ b/src/utils/discordUsers.js
@@ -1,0 +1,23 @@
+export function formatUserTag(user) {
+  if (!user) return "Unknown";
+  if (typeof user.tag === "string" && user.tag) return user.tag;
+  const username = user.username ?? user.globalName ?? null;
+  const discriminator = user.discriminator && user.discriminator !== "0" ? `#${user.discriminator}` : "";
+  if (username) return `${username}${discriminator}`;
+  return String(user.id ?? "Unknown");
+}
+
+export function getAvatarUrl(user, { size = 256 } = {}) {
+  if (!user?.displayAvatarURL) return null;
+  try {
+    return user.displayAvatarURL({ size });
+  } catch {
+    return null;
+  }
+}
+
+export function safeTimestamp(value) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) return value.getTime();
+  return null;
+}

--- a/src/utils/memberLog.js
+++ b/src/utils/memberLog.js
@@ -1,0 +1,16 @@
+import { CONFIG } from "../config.js";
+
+const FALLBACKS = {
+  join: 0x57F287,
+  leave: 0xED4245,
+  neutral: 0x5865F2
+};
+
+export function getMemberLogColors() {
+  const cfg = CONFIG.colors || {};
+  return {
+    join: cfg.green ?? FALLBACKS.join,
+    leave: cfg.red ?? FALLBACKS.leave,
+    neutral: cfg.neutral ?? cfg.default ?? FALLBACKS.neutral
+  };
+}

--- a/src/utils/memberLogEmbeds.js
+++ b/src/utils/memberLogEmbeds.js
@@ -1,0 +1,21 @@
+import { EmbedBuilder } from "discord.js";
+import { formatUserTag, getAvatarUrl } from "./discordUsers.js";
+
+export function createMemberEmbedBase({ member, user, title, color }) {
+  const resolvedUser = user ?? member?.user ?? null;
+  const embed = new EmbedBuilder()
+    .setTitle(title)
+    .setColor(color)
+    .setTimestamp(new Date());
+
+  const id = member?.id ?? resolvedUser?.id ?? null;
+  if (id) embed.setFooter({ text: `ID: ${id}` });
+
+  if (resolvedUser) {
+    const avatar = getAvatarUrl(resolvedUser);
+    embed.setAuthor({ name: formatUserTag(resolvedUser), iconURL: avatar ?? undefined });
+    if (avatar) embed.setThumbnail(avatar);
+  }
+
+  return { embed, user: resolvedUser };
+}


### PR DESCRIPTION
## Summary
- add a dedicated staff member log service that safely resolves the destination channel and reports delivery issues
- expand configuration to support staff log channel/colour overrides and expose shared member embed helpers
- emit rich embeds for member join, leave, and update events with role/name diffs routed to the staff log channel

## Testing
- not run (bot logging feature)


------
https://chatgpt.com/codex/tasks/task_e_68e20603a1d4832b8688ffe533a408c3