### PR TITLE
feat: enforce display name policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "discord-modbot",
       "version": "1.0.0",
       "dependencies": {
+        "any-ascii": "^0.3.3",
         "discord.js": "^14.16.3",
         "dotenv": "^16.4.5",
         "mongoose": "^8.6.0"
@@ -223,6 +224,15 @@
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/any-ascii": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/any-ascii/-/any-ascii-0.3.3.tgz",
+      "integrity": "sha512-8hm+zPrc1VnlxD5eRgMo9F9k2wEMZhbZVLKwA/sPKIt6ywuz7bI9uV/yb27uvc8fv8q6Wl2piJT51q1saKX0Jw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/bson": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check:commands": "node scripts/check-commands.js"
   },
   "dependencies": {
+    "any-ascii": "^0.3.3",
     "discord.js": "^14.16.3",
     "dotenv": "^16.4.5",
     "mongoose": "^8.6.0"

--- a/src/config.js
+++ b/src/config.js
@@ -114,6 +114,10 @@ const mentionTrackerDefaults = {
   additionalFlagChannelKeys: []
 };
 const mentionTrackerFileCfg = fileCfg?.mentionTracker || {};
+const displayNamePolicyDefaults = {
+  sweepIntervalMinutes: 60
+};
+const displayNamePolicyFileCfg = fileCfg?.displayNamePolicy || {};
 
 const mentionTrackerRoleRaw = process.env.MENTION_TRACKER_ROLE_IDS !== undefined
   ? process.env.MENTION_TRACKER_ROLE_IDS
@@ -177,6 +181,15 @@ export const CONFIG = {
     trackedRoleIds: toList(mentionTrackerRoleRaw),
     trackedUserIds: toList(mentionTrackerUserRaw),
     additionalFlagChannelKeys: toList(mentionTrackerExtraKeysRaw)
+  },
+  displayNamePolicy: {
+    sweepIntervalMinutes: toNumber(
+      envOr(
+        "DISPLAY_NAME_SWEEP_INTERVAL_MINUTES",
+        displayNamePolicyFileCfg.sweepIntervalMinutes ?? displayNamePolicyDefaults.sweepIntervalMinutes
+      ),
+      displayNamePolicyDefaults.sweepIntervalMinutes
+    )
   }
 };
 

--- a/src/container.js
+++ b/src/container.js
@@ -21,5 +21,6 @@ export const TOKENS = {
   VirusTotalService: "VirusTotalService",
   MentionTrackerService: "MentionTrackerService",
   AllowedInviteService: "AllowedInviteService",
-  VirusTotalService: "VirusTotalService"
+  VirusTotalService: "VirusTotalService",
+  DisplayNamePolicyService: "DisplayNamePolicyService"
 };

--- a/src/events/guildMemberAdd.displayNamePolicy.js
+++ b/src/events/guildMemberAdd.displayNamePolicy.js
@@ -1,0 +1,17 @@
+import { TOKENS } from "../container.js";
+
+export default {
+  name: "guildMemberAdd",
+  async execute(member) {
+    try {
+      const service = member.client?.container?.get(TOKENS.DisplayNamePolicyService);
+      await service?.handleMemberJoin?.(member);
+    } catch (err) {
+      member?.client?.container?.get(TOKENS.Logger)?.error?.("display_name_policy.member_add_failed", {
+        guildId: member.guild?.id,
+        userId: member.id,
+        error: String(err?.message || err)
+      });
+    }
+  }
+};

--- a/src/events/guildMemberUpdate.displayNamePolicy.js
+++ b/src/events/guildMemberUpdate.displayNamePolicy.js
@@ -1,0 +1,17 @@
+import { TOKENS } from "../container.js";
+
+export default {
+  name: "guildMemberUpdate",
+  async execute(oldMember, newMember) {
+    try {
+      const service = newMember?.client?.container?.get(TOKENS.DisplayNamePolicyService);
+      await service?.handleMemberUpdate?.(newMember, oldMember);
+    } catch (err) {
+      newMember?.client?.container?.get(TOKENS.Logger)?.error?.("display_name_policy.member_update_failed", {
+        guildId: newMember?.guild?.id,
+        userId: newMember?.id,
+        error: String(err?.message || err)
+      });
+    }
+  }
+};

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -23,5 +23,14 @@ export default {
         error: String(err?.message || err)
       });
     }
+
+    try {
+      const displayNamePolicyService = client.container.get(TOKENS.DisplayNamePolicyService);
+      await displayNamePolicyService.onClientReady(client);
+    } catch (err) {
+      client.container.get(TOKENS.Logger)?.error?.("display_name_policy.ready_failed", {
+        error: String(err?.message || err)
+      });
+    }
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import { StaffMemberLogService } from "./services/StaffMemberLogService.js";
 import { AllowedInviteService } from "./services/AllowedInviteService.js";
 import { VirusTotalService } from "./services/VirusTotalService.js";
 import { MentionTrackerService } from "./services/MentionTrackerService.js";
+import { DisplayNamePolicyService } from "./services/DisplayNamePolicyService.js";
 
 async function main() {
   await connectMongo();
@@ -69,6 +70,12 @@ async function main() {
     fallbackChannelId: CONFIG.modLogChannelId
   });
   container.set(TOKENS.MentionTrackerService, mentionTrackerService);
+
+  const displayNamePolicyService = new DisplayNamePolicyService({
+    logger,
+    sweepIntervalMinutes: CONFIG.displayNamePolicy?.sweepIntervalMinutes ?? 60
+  });
+  container.set(TOKENS.DisplayNamePolicyService, displayNamePolicyService);
 
   // Plugins
   const pluginDirs = (CONFIG.privateModuleDirs || []).map(p => resolve(process.cwd(), p));

--- a/src/services/DisplayNamePolicyService.js
+++ b/src/services/DisplayNamePolicyService.js
@@ -1,0 +1,189 @@
+import anyAscii from "any-ascii";
+
+export function isAscii(ch) {
+  if (!ch) return false;
+  const cp = ch.codePointAt(0);
+  return cp !== undefined && cp < 128;
+}
+
+export function isPrintableAscii(ch) {
+  if (!ch) return false;
+  const cp = ch.codePointAt(0);
+  return cp !== undefined && cp >= 0x21 && cp < 0x7F;
+}
+
+export function isValidName(name) {
+  if (!name) return false;
+
+  let hasThreePrintable = false;
+  let printableRun = 0;
+  let firstCharChecked = false;
+  let firstCharAscii = false;
+  let allAscii = true;
+
+  for (const ch of name) {
+    if (!firstCharChecked) {
+      firstCharAscii = isAscii(ch);
+      firstCharChecked = true;
+    }
+
+    const ascii = isAscii(ch);
+    if (!ascii) allAscii = false;
+
+    if (isPrintableAscii(ch)) {
+      printableRun += 1;
+      if (printableRun >= 3) {
+        hasThreePrintable = true;
+      }
+    } else {
+      printableRun = 0;
+    }
+  }
+
+  if (!firstCharChecked) return false;
+
+  return allAscii || firstCharAscii || hasThreePrintable;
+}
+
+export function normalizeName(nick, username) {
+  const trySources = [nick, username];
+  for (const source of trySources) {
+    const transliterated = anyAscii(source ?? "");
+    const trimmed = transliterated.trim();
+    if (trimmed) {
+      return trimmed.slice(0, 32);
+    }
+  }
+  return "Monke";
+}
+
+export function hasShouting(nick) {
+  if (!nick) return false;
+  return /[A-Z]{4,}/.test(nick);
+}
+
+export class DisplayNamePolicyService {
+  #logger;
+  #sweepIntervalMinutes;
+  #intervalHandle = null;
+
+  constructor({ logger, sweepIntervalMinutes = 60 } = {}) {
+    this.#logger = logger;
+    this.#sweepIntervalMinutes = Number.isFinite(sweepIntervalMinutes) && sweepIntervalMinutes > 0
+      ? sweepIntervalMinutes
+      : 60;
+  }
+
+  async onClientReady(client) {
+    await this.runFullSweep(client).catch((err) => {
+      this.#logger?.error?.("display_name_policy.initial_sweep_failed", { error: String(err?.message || err) });
+    });
+    this.#scheduleSweep(client);
+  }
+
+  async handleMemberJoin(member) {
+    await this.#applyPolicies(member, "member_join");
+  }
+
+  async handleMemberUpdate(newMember, oldMember) {
+    const before = oldMember?.displayName ?? oldMember?.nickname ?? null;
+    const after = newMember?.displayName ?? newMember?.nickname ?? null;
+    if (before !== after) {
+      await this.#applyPolicies(newMember, "member_update");
+    }
+  }
+
+  async runFullSweep(client) {
+    for (const guild of client.guilds.cache.values()) {
+      let members;
+      try {
+        members = await guild.members.fetch();
+      } catch (err) {
+        this.#logger?.error?.("display_name_policy.sweep_fetch_failed", {
+          guildId: guild.id,
+          error: String(err?.message || err)
+        });
+        continue;
+      }
+
+      for (const member of members.values()) {
+        await this.#applyPolicies(member, "scheduled_sweep");
+      }
+    }
+  }
+
+  async #applyPolicies(member, source) {
+    if (!member) return;
+
+    let displayName = member.displayName || member.nickname || member.user?.globalName || member.user?.username || "";
+
+    if (!isValidName(displayName)) {
+      const normalized = normalizeName(
+        member.nickname ?? displayName,
+        member.user?.globalName ?? member.user?.username ?? ""
+      );
+      const changed = await this.#setNickname(member, normalized, `${source}:normalize`);
+      if (changed) {
+        displayName = normalized;
+      }
+    }
+
+    if (hasShouting(displayName)) {
+      const lowered = displayName.toLowerCase();
+      const changed = await this.#setNickname(member, lowered, `${source}:lowercase`);
+      if (changed) {
+        displayName = lowered;
+      }
+    }
+  }
+
+  async #setNickname(member, nickname, reasonTag) {
+    if (!nickname) return false;
+
+    const current = member.nickname ?? "";
+    if (current === nickname) return false;
+
+    if (!member.manageable) {
+      this.#logger?.info?.("display_name_policy.unmanageable", {
+        guildId: member.guild?.id,
+        userId: member.id,
+        reason: reasonTag
+      });
+      return false;
+    }
+
+    try {
+      await member.setNickname(nickname, "Display name policy enforcement");
+      this.#logger?.info?.("display_name_policy.nickname_set", {
+        guildId: member.guild?.id,
+        userId: member.id,
+        nickname,
+        reason: reasonTag
+      });
+      return true;
+    } catch (err) {
+      this.#logger?.error?.("display_name_policy.nickname_failed", {
+        guildId: member.guild?.id,
+        userId: member.id,
+        reason: reasonTag,
+        error: String(err?.message || err)
+      });
+      return false;
+    }
+  }
+
+  #scheduleSweep(client) {
+    if (this.#intervalHandle) {
+      clearInterval(this.#intervalHandle);
+    }
+
+    const intervalMs = Math.max(1, Math.floor(this.#sweepIntervalMinutes)) * 60_000;
+    const handle = setInterval(() => {
+      this.runFullSweep(client).catch((err) => {
+        this.#logger?.error?.("display_name_policy.sweep_failed", { error: String(err?.message || err) });
+      });
+    }, intervalMs);
+    handle.unref?.();
+    this.#intervalHandle = handle;
+  }
+}

--- a/src/services/__tests__/DisplayNamePolicyService.test.js
+++ b/src/services/__tests__/DisplayNamePolicyService.test.js
@@ -1,0 +1,116 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  DisplayNamePolicyService,
+  isValidName,
+  normalizeName,
+  hasShouting
+} from "../DisplayNamePolicyService.js";
+
+const createLogger = () => {
+  const entries = { info: [], error: [] };
+  return {
+    info(event, payload) { entries.info.push({ event, payload }); },
+    error(event, payload) { entries.error.push({ event, payload }); },
+    entries
+  };
+};
+
+const createMember = ({
+  id = "1",
+  displayName = "",
+  nickname = null,
+  manageable = true,
+  user = { username: "User", globalName: null },
+  guildId = "guild1"
+} = {}) => {
+  const member = {
+    id,
+    nickname,
+    displayName,
+    manageable,
+    guild: { id: guildId },
+    user,
+    setNickname: (newNick) => {
+      member.nickname = newNick;
+      member.displayName = newNick;
+      return Promise.resolve(member);
+    }
+  };
+  return member;
+};
+
+test("emoji-only names are normalized via transliteration", async () => {
+  assert.equal(isValidName("😀😀"), false);
+  const transliteration = normalizeName("😀😀", "😀😀");
+  assert.equal(transliteration, ":grinning::grinning:");
+  assert.ok(transliteration.length <= 32);
+
+  const logger = createLogger();
+  const service = new DisplayNamePolicyService({ logger });
+  const member = createMember({ displayName: "😀😀", nickname: "😀😀", user: { username: "Readable" } });
+
+  await service.handleMemberJoin(member);
+  assert.equal(member.nickname, ":grinning::grinning:");
+  assert.equal(member.displayName, ":grinning::grinning:");
+});
+
+test("names starting with ASCII are allowed", () => {
+  assert.equal(isValidName("A🌀"), true);
+});
+
+test("names with three consecutive printable ASCII are allowed", () => {
+  assert.equal(isValidName("😀abc😀"), true);
+});
+
+test("normalizeName falls back to Monke when transliteration is empty", () => {
+  assert.equal(normalizeName("   ", "   "), "Monke");
+});
+
+test("invalid names without printable ASCII are replaced", async () => {
+  const logger = createLogger();
+  const service = new DisplayNamePolicyService({ logger });
+  const member = createMember({ displayName: "ååå", nickname: "ååå", user: { username: "Valid" } });
+
+  await service.handleMemberJoin(member);
+  assert.equal(member.nickname, "aaa");
+});
+
+test("shouting names are lowercased", async () => {
+  assert.equal(hasShouting("AAAA"), true);
+  const logger = createLogger();
+  const service = new DisplayNamePolicyService({ logger });
+  const member = createMember({ displayName: "AAAAA", nickname: "AAAAA", user: { username: "aaaaa" } });
+
+  await service.handleMemberJoin(member);
+  assert.equal(member.nickname, "aaaaa");
+});
+
+test("hourly sweep applies policies to all members", async () => {
+  const logger = createLogger();
+  const service = new DisplayNamePolicyService({ logger });
+
+  const members = [
+    createMember({ id: "1", displayName: "😀😀", nickname: "😀😀", user: { username: "User1" } }),
+    createMember({ id: "2", displayName: "BBBB", nickname: "BBBB", user: { username: "BBBB" } })
+  ];
+
+  const guild = {
+    id: "guild1",
+    members: {
+      fetch: async () => new Map(members.map((m) => [m.id, m]))
+    }
+  };
+
+  const client = {
+    guilds: {
+      cache: new Map([[guild.id, guild]])
+    }
+  };
+
+  await service.runFullSweep(client);
+
+  assert.equal(members[0].nickname, ":grinning::grinning:");
+  assert.equal(members[1].nickname, "bbbb");
+  assert.equal(logger.entries.error.length, 0);
+});


### PR DESCRIPTION
## Summary
- add a display name policy service that validates member nicknames, normalizes unreadable names, and enforces anti-shouting rules on joins, updates, and scheduled sweeps
- register the service with the container, wire it into ready/member events, and expose configuration for sweep intervals
- add helper unit tests covering validation, normalization, shouting detection, and scheduled sweep behavior

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68e20a8c6a48832bb66bdc3416849806