### PR TITLE
Fix duplicate service registration and add duration utility tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "node --env-file=.env src/index.js",
     "deploy": "node --env-file=.env scripts/deploy-commands.js",
     "start": "node src/index.js",
-    "check:commands": "node scripts/check-commands.js"
+    "check:commands": "node scripts/check-commands.js",
+    "test": "node --test"
   },
   "dependencies": {
     "any-ascii": "^0.3.3",

--- a/src/container.js
+++ b/src/container.js
@@ -21,6 +21,5 @@ export const TOKENS = {
   VirusTotalService: "VirusTotalService",
   MentionTrackerService: "MentionTrackerService",
   AllowedInviteService: "AllowedInviteService",
-  VirusTotalService: "VirusTotalService",
   DisplayNamePolicyService: "DisplayNamePolicyService"
 };

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,6 @@ async function main() {
   container.set(TOKENS.ChannelMapService, channelMapService);
   const staffRoleService = new StaffRoleService();
   container.set(TOKENS.StaffRoleService, staffRoleService);
-  container.set(TOKENS.StaffRoleService, new StaffRoleService());
   container.set(TOKENS.AntiSpamService, new AntiSpamService(CONFIG.antiSpam));
   container.set(TOKENS.RuntimeModerationState, new RuntimeModerationState());
   container.set(TOKENS.StaffMemberLogService, new StaffMemberLogService({

--- a/test/utils/time.test.js
+++ b/test/utils/time.test.js
@@ -1,0 +1,116 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseDuration,
+  formatDuration,
+  scheduleWithMaxTimeout,
+  MAX_TIMEOUT_DURATION
+} from "../../src/utils/time.js";
+
+const waitForMicrotasks = () => new Promise(resolve => setImmediate(resolve));
+
+test("parseDuration parses multi-unit inputs", () => {
+  const result = parseDuration("1h 30m");
+  assert.equal(result.ms, 5_400_000);
+  assert.deepEqual(result.parts, [
+    { value: 1, unit: "h" },
+    { value: 30, unit: "m" }
+  ]);
+  assert.equal(result.human, "1h 30m");
+});
+
+test("parseDuration handles numeric strings with default unit", () => {
+  const result = parseDuration("15", { defaultUnit: "m" });
+  assert.equal(result.ms, 900_000);
+  assert.deepEqual(result.parts, [{ value: 15, unit: "m" }]);
+});
+
+test("parseDuration returns permanent marker", () => {
+  const result = parseDuration("permanent");
+  assert.equal(result.ms, null);
+  assert.equal(result.human, "permanent");
+  assert.deepEqual(result.parts, []);
+});
+
+test("parseDuration rejects unknown units", () => {
+  assert.throws(() => parseDuration("5 lightyears"), /Unknown duration unit/i);
+});
+
+test("formatDuration compresses durations", () => {
+  assert.equal(formatDuration(3_660_000), "1h 1m");
+  assert.equal(formatDuration(999), "<1s");
+});
+
+test("scheduleWithMaxTimeout executes callback for zero delay", async () => {
+  let called = false;
+  scheduleWithMaxTimeout(() => { called = true; }, 0);
+  await waitForMicrotasks();
+  assert.equal(called, true);
+});
+
+test("scheduleWithMaxTimeout respects cancellation", async () => {
+  let called = false;
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  try {
+    const handles = new Map();
+    let nextHandle = 1;
+    globalThis.setTimeout = (fn, delay) => {
+      const handle = nextHandle++;
+      handles.set(handle, fn);
+      return handle;
+    };
+    globalThis.clearTimeout = (handle) => {
+      handles.delete(handle);
+    };
+
+    const timer = scheduleWithMaxTimeout(() => { called = true; }, 10_000);
+    timer.cancel();
+
+    // simulate passage of time
+    for (const fn of handles.values()) {
+      fn();
+    }
+    await waitForMicrotasks();
+    assert.equal(called, false);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});
+
+test("scheduleWithMaxTimeout splits long durations", async () => {
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  const delays = [];
+  try {
+    const handles = new Map();
+    let nextHandle = 1;
+    globalThis.setTimeout = (fn, delay) => {
+      const handle = nextHandle++;
+      delays.push(delay);
+      handles.set(handle, fn);
+      queueMicrotask(() => {
+        if (handles.has(handle)) {
+          handles.delete(handle);
+          fn();
+        }
+      });
+      return handle;
+    };
+    globalThis.clearTimeout = (handle) => {
+      handles.delete(handle);
+    };
+
+    let callCount = 0;
+    scheduleWithMaxTimeout(() => { callCount += 1; }, MAX_TIMEOUT_DURATION + 1234);
+    await waitForMicrotasks();
+    await waitForMicrotasks();
+    assert.equal(callCount, 1);
+    assert.ok(delays[0] <= MAX_TIMEOUT_DURATION);
+    assert.ok(delays.length >= 2);
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});


### PR DESCRIPTION
## Summary
- prevent the StaffRoleService from being instantiated twice when building the container
- remove the duplicate VirusTotalService token entry from the service container map
- add a node:test suite for time utility helpers and expose it via an npm script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e20c00c964832ba84bd8f43dbbc192