### PR TITLE
Add default staff log channel fallbacks

### DIFF
--- a/src/services/StaffMemberLogService.js
+++ b/src/services/StaffMemberLogService.js
@@ -1,4 +1,5 @@
 import { Collection } from "discord.js";
+import { findDefaultStaffChannel } from "../utils/staffChannels.js";
 
 const CHANNEL_MAP_KEYS = [
   "staff_member_log",
@@ -92,6 +93,12 @@ export class StaffMemberLogService {
           }
         }
       }
+    }
+
+    const defaultChannel = findDefaultStaffChannel(guild, CHANNEL_MAP_KEYS, isTextSendable);
+    if (defaultChannel) {
+      this.#cache.set(guild.id, { channel: defaultChannel, resolvedAt: Date.now() });
+      return defaultChannel;
     }
 
     const fallbackId = await this.#resolveFallbackId(guild).catch(() => this.fallbackChannelId);

--- a/src/utils/staffChannels.js
+++ b/src/utils/staffChannels.js
@@ -1,3 +1,70 @@
+const DEFAULT_CHANNEL_CANDIDATES = new Map(
+  Object.entries({
+    flag_log: ["flag-log"],
+    experimental_log: ["experimental-log"],
+    action_log: ["action-log", "staff-action-log"],
+    staff_action_log: ["action-log", "staff-action-log"],
+    join_boost_log: ["join-boost-log"],
+    brand_new_alert: ["brand-new-alert", "join-boost-log"],
+    member_log: ["member-log", "staff-member-log"],
+    staff_member_log: ["member-log", "staff-member-log"],
+    message_log: ["message-log"],
+    bot_log: ["bot-log"],
+    mod_log: ["mod-log", "moderator-log"]
+  }).map(([key, names]) => [
+    key,
+    new Set(names.map((name) => normalizeChannelName(name)).filter(Boolean))
+  ])
+);
+
+function normalizeChannelName(name) {
+  return String(name ?? "")
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, "")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "")
+    .trim();
+}
+
+function toKeyArray(preferredKeys) {
+  if (Array.isArray(preferredKeys)) {
+    return preferredKeys.filter(Boolean);
+  }
+  return preferredKeys ? [preferredKeys] : [];
+}
+
+function defaultChannelPredicate(channel) {
+  if (!channel?.isTextBased?.()) return false;
+  if (typeof channel.isThread === "function" && channel.isThread()) return false;
+  return true;
+}
+
+export function findDefaultStaffChannel(guild, preferredKeys, predicate = defaultChannelPredicate) {
+  if (!guild?.channels?.cache?.values) return null;
+  const keys = toKeyArray(preferredKeys);
+  if (!keys.length) return null;
+
+  const seen = new Set();
+  for (const key of keys) {
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const candidates = DEFAULT_CHANNEL_CANDIDATES.get(key);
+    if (!candidates?.size) continue;
+
+    for (const channel of guild.channels.cache.values()) {
+      if (!predicate(channel)) continue;
+      const normalized = normalizeChannelName(channel.name);
+      if (!normalized) continue;
+      if (candidates.has(normalized)) {
+        return channel;
+      }
+    }
+  }
+
+  return null;
+}
+
 export async function resolveStaffChannel(guild, channelMapService, preferredKeys, fallback) {
   if (!guild) return null;
 
@@ -15,7 +82,7 @@ export async function resolveStaffChannel(guild, channelMapService, preferredKey
     }
   };
 
-  const keys = Array.isArray(preferredKeys) ? preferredKeys : [preferredKeys].filter(Boolean);
+  const keys = toKeyArray(preferredKeys);
   if (channelMapService) {
     for (const key of keys) {
       try {
@@ -28,6 +95,9 @@ export async function resolveStaffChannel(guild, channelMapService, preferredKey
       }
     }
   }
+
+  const defaultChannel = findDefaultStaffChannel(guild, keys);
+  if (defaultChannel) return defaultChannel;
 
   const fallbackId = await (async () => {
     if (typeof fallback === "function") {

--- a/test/staffChannels.test.js
+++ b/test/staffChannels.test.js
@@ -19,11 +19,15 @@ function createGuild(channels) {
   };
 }
 
-function createChannel(id) {
+function createChannel(id, name = "channel") {
   return {
     id,
+    name,
     isTextBased() {
       return true;
+    },
+    isThread() {
+      return false;
     }
   };
 }
@@ -57,4 +61,21 @@ test("prefers mapped channels before falling back", async () => {
   const channel = await resolveStaffChannel(guild, channelMapService, ["primary", "secondary"], "000");
   assert.ok(channel);
   assert.equal(channel.id, "789");
+});
+
+test("uses default log channel names when available", async () => {
+  const guild = createGuild([
+    createChannel("flag", "🚩-flag-log"),
+    createChannel("fallback", "fallback")
+  ]);
+
+  const channelMapService = {
+    async get() {
+      return null;
+    }
+  };
+
+  const channel = await resolveStaffChannel(guild, channelMapService, "flag_log", "fallback");
+  assert.ok(channel);
+  assert.equal(channel.id, "flag");
 });


### PR DESCRIPTION
## Summary
- add default log channel name candidates and helper to discover them automatically
- fall back to matching default log channels when resolving staff member log destinations
- cover the new behaviour with unit tests for staff channel resolution

## Testing
- npm test *(fails: missing `any-ascii` dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e21834e1b4832b957f0bb8c196bb0d