### PR TITLE
Add server overview metrics to private dashboard

### DIFF
--- a/modules/bot-private/src/services/DashboardService.js
+++ b/modules/bot-private/src/services/DashboardService.js
@@ -5,6 +5,7 @@ import helmet from "helmet";
 import rateLimit from "express-rate-limit";
 import bcrypt from "bcryptjs";
 import { createServer } from "node:http";
+import { ChannelType } from "discord.js";
 
 export class DashboardService {
   #logger;
@@ -147,6 +148,16 @@ export class DashboardService {
     });
 
     router.use("/api", this.#authMiddleware());
+
+    router.get("/api/stats", async (req, res) => {
+      try {
+        const guildId = req.query.guildId ? String(req.query.guildId) : null;
+        const stats = await this.#fetchServerStats({ guildId });
+        res.json(stats);
+      } catch (error) {
+        this.#handleRouteError(error, res, "dashboard.stats.error");
+      }
+    });
 
     router.get("/api/users", async (req, res) => {
       try {
@@ -378,6 +389,206 @@ export class DashboardService {
     return this.#sessionSecret;
   }
 
+  async #fetchServerStats({ guildId }) {
+    const generatedAt = new Date().toISOString();
+    const client = this.#client;
+
+    const totals = {
+      guilds: 0,
+      members: 0,
+      approxPresences: 0,
+      channels: 0,
+      textChannels: 0,
+      voiceChannels: 0,
+      categoryChannels: 0,
+      forumChannels: 0,
+      stageChannels: 0,
+      announcementChannels: 0,
+      threadChannels: 0,
+      roles: 0,
+      emojis: 0,
+      stickers: 0,
+      boosts: 0
+    };
+
+    if (!client) {
+      return { totals, guilds: [], generatedAt };
+    }
+
+    const allowList = Array.isArray(this.#config.guildAllowList)
+      ? this.#config.guildAllowList.map((value) => String(value).trim()).filter(Boolean)
+      : [];
+
+    const targetGuildIds = new Set();
+
+    if (guildId) {
+      if (!allowList.length || allowList.includes(guildId)) {
+        targetGuildIds.add(guildId);
+      }
+    } else if (allowList.length) {
+      allowList.forEach((id) => targetGuildIds.add(id));
+    } else {
+      client.guilds.cache?.forEach?.((guild) => targetGuildIds.add(guild.id));
+    }
+
+    if (!targetGuildIds.size) {
+      try {
+        const fetched = await client.guilds.fetch();
+        fetched?.forEach?.((_guild, id) => targetGuildIds.add(id));
+      } catch {
+        // ignore fetch failures; fall back to whatever we already have
+      }
+    }
+
+    const guildStats = [];
+
+    for (const id of targetGuildIds) {
+      const guild = client.guilds.cache?.get?.(id) ?? await client.guilds.fetch(id).catch(() => null);
+      if (!guild) continue;
+
+      let fetchedGuild = guild;
+      try {
+        fetchedGuild = await guild.fetch();
+      } catch {
+        // ignore if fetch fails; we will use whatever data is cached
+      }
+
+      let channelsCollection = guild.channels?.cache;
+      try {
+        const fetchedChannels = await guild.channels?.fetch();
+        if (fetchedChannels) {
+          channelsCollection = fetchedChannels;
+        }
+      } catch {
+        // ignore channel fetch failures
+      }
+
+      try {
+        await guild.roles?.fetch?.();
+      } catch {
+        // ignore role fetch failures
+      }
+
+      try {
+        await guild.emojis?.fetch?.();
+      } catch {
+        // ignore emoji fetch failures
+      }
+
+      try {
+        await guild.stickers?.fetch?.();
+      } catch {
+        // ignore sticker fetch failures
+      }
+
+      const channelCounts = {
+        total: 0,
+        text: 0,
+        voice: 0,
+        category: 0,
+        forum: 0,
+        stage: 0,
+        announcement: 0,
+        thread: 0
+      };
+
+      channelsCollection?.forEach?.((channel) => {
+        if (!channel) return;
+        channelCounts.total += 1;
+        switch (channel.type) {
+          case ChannelType.GuildText:
+            channelCounts.text += 1;
+            break;
+          case ChannelType.GuildVoice:
+            channelCounts.voice += 1;
+            break;
+          case ChannelType.GuildCategory:
+            channelCounts.category += 1;
+            break;
+          case ChannelType.GuildForum:
+            channelCounts.forum += 1;
+            break;
+          case ChannelType.GuildStageVoice:
+            channelCounts.stage += 1;
+            break;
+          case ChannelType.GuildAnnouncement:
+            channelCounts.announcement += 1;
+            break;
+          case ChannelType.PublicThread:
+          case ChannelType.PrivateThread:
+          case ChannelType.AnnouncementThread:
+            channelCounts.thread += 1;
+            break;
+          default:
+            break;
+        }
+      });
+
+      const memberCount = Number.isFinite(fetchedGuild?.memberCount)
+        ? fetchedGuild.memberCount
+        : (Number.isFinite(guild.memberCount) ? guild.memberCount : null);
+      const approximateMemberCount = Number.isFinite(fetchedGuild?.approximateMemberCount)
+        ? fetchedGuild.approximateMemberCount
+        : null;
+      const approxPresenceCount = Number.isFinite(fetchedGuild?.approximatePresenceCount)
+        ? fetchedGuild.approximatePresenceCount
+        : null;
+      const resolvedMemberCount = Number.isFinite(memberCount)
+        ? memberCount
+        : (Number.isFinite(approximateMemberCount) ? approximateMemberCount : null);
+
+      const roleCount = guild.roles?.cache?.size ?? 0;
+      const emojiCount = guild.emojis?.cache?.size ?? 0;
+      const stickerCount = guild.stickers?.cache?.size ?? 0;
+      const boostCount = Number.isFinite(fetchedGuild?.premiumSubscriptionCount)
+        ? fetchedGuild.premiumSubscriptionCount
+        : (Number.isFinite(guild.premiumSubscriptionCount) ? guild.premiumSubscriptionCount : null);
+
+      const guildData = {
+        id: guild.id,
+        name: fetchedGuild?.name ?? guild.name ?? guild.id,
+        iconUrl: this.#resolveGuildIcon(fetchedGuild ?? guild),
+        memberCount: resolvedMemberCount,
+        approxPresenceCount,
+        channelCounts,
+        roleCount,
+        emojiCount,
+        stickerCount,
+        boostLevel: fetchedGuild?.premiumTier ?? guild.premiumTier ?? null,
+        boostCount,
+        ownerId: fetchedGuild?.ownerId ?? guild.ownerId ?? null,
+        createdAt: fetchedGuild?.createdAt instanceof Date
+          ? fetchedGuild.createdAt.toISOString()
+          : (guild.createdAt instanceof Date ? guild.createdAt.toISOString() : null),
+        shardId: typeof fetchedGuild?.shardId === "number"
+          ? fetchedGuild.shardId
+          : (typeof guild.shardId === "number" ? guild.shardId : null)
+      };
+
+      guildStats.push(guildData);
+
+      totals.guilds += 1;
+      if (Number.isFinite(resolvedMemberCount)) totals.members += resolvedMemberCount;
+      if (Number.isFinite(approxPresenceCount)) totals.approxPresences += approxPresenceCount;
+      totals.channels += channelCounts.total;
+      totals.textChannels += channelCounts.text;
+      totals.voiceChannels += channelCounts.voice;
+      totals.categoryChannels += channelCounts.category;
+      totals.forumChannels += channelCounts.forum;
+      totals.stageChannels += channelCounts.stage;
+      totals.announcementChannels += channelCounts.announcement;
+      totals.threadChannels += channelCounts.thread;
+      totals.roles += roleCount;
+      totals.emojis += emojiCount;
+      totals.stickers += stickerCount;
+      if (Number.isFinite(boostCount)) totals.boosts += boostCount;
+    }
+
+    guildStats.sort((a, b) => a.name.localeCompare(b.name));
+
+    return { totals, guilds: guildStats, generatedAt };
+  }
+
   async #fetchUserSummaries({ guildId }) {
     const allowList = Array.isArray(this.#config.guildAllowList) ? this.#config.guildAllowList : [];
     const restrictGuild = guildId || (allowList.length ? allowList : null);
@@ -587,6 +798,16 @@ export class DashboardService {
     return base;
   }
 
+  #resolveGuildIcon(guild) {
+    if (!guild) return null;
+    try {
+      const icon = guild.iconURL?.({ size: 128 });
+      return icon || null;
+    } catch {
+      return null;
+    }
+  }
+
   #handleRouteError(error, res, logKey) {
     const message = error instanceof Error ? error.message : String(error);
     this.#logger?.error?.(logKey, { error: message });
@@ -629,6 +850,14 @@ export class DashboardService {
     .card { background: rgba(15, 23, 42, 0.9); border: 1px solid #1e293b; border-radius: 0.75rem; padding: 1.5rem; margin-top: 1rem; }
     form { display: flex; flex-direction: column; gap: 1rem; }
     .actions { display: flex; gap: 0.75rem; align-items: center; }
+    .subsection { margin-top: 1.5rem; }
+    .stats-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 1rem; margin-top: 1rem; }
+    .stat-pill { background: rgba(30, 64, 175, 0.35); border: 1px solid rgba(30, 64, 175, 0.6); border-radius: 0.75rem; padding: 1rem; display: flex; flex-direction: column; gap: 0.25rem; box-shadow: inset 0 0 0 1px rgba(30, 58, 138, 0.2); }
+    .stat-pill .label { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; color: #cbd5f5; }
+    .stat-pill .value { font-size: 1.5rem; font-weight: 600; color: #f8fafc; }
+    .stats-table { margin-top: 1rem; overflow-x: auto; }
+    .guild-cell { display: flex; align-items: center; gap: 0.75rem; }
+    .guild-icon { width: 32px; height: 32px; border-radius: 25%; background: #1e293b; object-fit: cover; }
   </style>
 </head>
 <body>
@@ -663,21 +892,46 @@ export class DashboardService {
         </div>
         <button id="logout-btn" type="button" style="background:#ef4444;">Log out</button>
       </div>
-      <div id="status" class="meta" style="margin-top: 1rem;">Loading…</div>
-      <div class="error" id="error" hidden></div>
-      <table id="user-table" hidden>
-        <thead>
-          <tr>
-            <th>User</th>
-            <th>Warnings</th>
-            <th>Actions</th>
-            <th>Last Warning</th>
-            <th>Last Action</th>
-            <th>Guilds</th>
-          </tr>
-        </thead>
-        <tbody></tbody>
-      </table>
+      <section id="stats-section" class="subsection">
+        <h2>Server Overview</h2>
+        <div id="stats-status" class="meta">Loading…</div>
+        <div class="error" id="stats-error" hidden></div>
+        <div id="stats-summary" class="stats-grid" hidden></div>
+        <div class="stats-table" id="guild-stats-wrapper" hidden>
+          <table id="guild-stats-table">
+            <thead>
+              <tr>
+                <th>Guild</th>
+                <th>Members</th>
+                <th>Online</th>
+                <th>Channels</th>
+                <th>Roles</th>
+                <th>Emoji &amp; Stickers</th>
+                <th>Boosts</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+      <section id="users-section" class="subsection">
+        <h2>User Moderation Activity</h2>
+        <div id="status" class="meta">Loading…</div>
+        <div class="error" id="error" hidden></div>
+        <table id="user-table" hidden>
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Warnings</th>
+              <th>Actions</th>
+              <th>Last Warning</th>
+              <th>Last Action</th>
+              <th>Guilds</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </section>
     </section>
   </main>
   <script>
@@ -700,6 +954,25 @@ export class DashboardService {
     const refreshBtn = document.getElementById('refresh-btn');
     const logoutBtn = document.getElementById('logout-btn');
     const sessionMeta = document.getElementById('session-meta');
+    const statsStatusEl = document.getElementById('stats-status');
+    const statsErrorEl = document.getElementById('stats-error');
+    const statsSummaryEl = document.getElementById('stats-summary');
+    const guildStatsWrapper = document.getElementById('guild-stats-wrapper');
+    const guildStatsTable = document.getElementById('guild-stats-table');
+    const guildStatsBody = guildStatsTable.querySelector('tbody');
+
+    const numberFormatter = new Intl.NumberFormat();
+    const compactNumberFormatter = new Intl.NumberFormat(undefined, { notation: 'compact', maximumFractionDigits: 1 });
+
+    function formatNumber(value) {
+      if (typeof value !== 'number' || !Number.isFinite(value)) return '—';
+      return numberFormatter.format(value);
+    }
+
+    function formatCompact(value) {
+      if (typeof value !== 'number' || !Number.isFinite(value)) return '—';
+      return compactNumberFormatter.format(value);
+    }
 
     function updateView() {
       if (isAuthenticated) {
@@ -715,6 +988,7 @@ export class DashboardService {
     }
 
     async function fetchSession() {
+      statsStatusEl.textContent = 'Checking session…';
       try {
         const res = await fetch(AUTH_BASE + '/session', { credentials: 'include' });
         if (!res.ok) throw new Error('Session check failed');
@@ -730,12 +1004,177 @@ export class DashboardService {
       currentUser = username || '';
       updateView();
       if (state) {
-        fetchUsers();
+        statsStatusEl.textContent = 'Loading server stats…';
+        statsErrorEl.hidden = true;
+        statsSummaryEl.hidden = true;
+        guildStatsWrapper.hidden = true;
+        statusEl.textContent = 'Loading…';
+        errorEl.hidden = true;
+        tableEl.hidden = true;
+        refreshAll();
       } else {
         statusEl.textContent = 'You must sign in to view data.';
         tableEl.hidden = true;
         errorEl.hidden = true;
+        statsStatusEl.textContent = 'You must sign in to view server metrics.';
+        statsErrorEl.hidden = true;
+        statsSummaryEl.hidden = true;
+        guildStatsWrapper.hidden = true;
       }
+    }
+
+    async function fetchStats() {
+      if (!isAuthenticated) return;
+      statsStatusEl.textContent = 'Loading server stats…';
+      statsErrorEl.hidden = true;
+      statsSummaryEl.hidden = true;
+      guildStatsWrapper.hidden = true;
+      guildStatsBody.innerHTML = '';
+
+      const params = new URLSearchParams();
+      const guildId = guildFilterEl.value.trim();
+      if (guildId) params.set('guildId', guildId);
+
+      try {
+        const query = params.toString();
+        const url = API_BASE + '/stats' + (query ? ('?' + query) : '');
+        const res = await fetch(url, { credentials: 'include' });
+        if (res.status === 401 || res.status === 403) {
+          setAuthenticated(false, '');
+          loginErrorEl.textContent = 'Session expired. Please sign in again.';
+          loginErrorEl.hidden = false;
+          return;
+        }
+        if (!res.ok) {
+          throw new Error('Request failed with status ' + res.status);
+        }
+        const data = await res.json();
+        renderStats(data);
+        const timestamp = data?.generatedAt ? new Date(data.generatedAt).toLocaleString() : new Date().toLocaleString();
+        statsStatusEl.textContent = 'Last updated ' + timestamp;
+      } catch (error) {
+        statsStatusEl.textContent = 'Failed to load server stats';
+        statsErrorEl.textContent = error.message || 'Unknown error';
+        statsErrorEl.hidden = false;
+      }
+    }
+
+    function renderStats(data) {
+      const totals = data?.totals || {};
+      const guilds = Array.isArray(data?.guilds) ? data.guilds : [];
+
+      const summaryItems = [
+        { label: 'Guilds', value: formatNumber(totals.guilds ?? 0) },
+        { label: 'Members', value: formatCompact(totals.members ?? 0) },
+        { label: 'Online', value: formatCompact(totals.approxPresences ?? 0) },
+        { label: 'Channels', value: formatCompact(totals.channels ?? 0) },
+        { label: 'Roles', value: formatCompact(totals.roles ?? 0) },
+        { label: 'Emoji', value: formatCompact(totals.emojis ?? 0) },
+        { label: 'Boosts', value: formatNumber(totals.boosts ?? 0) }
+      ];
+
+      statsSummaryEl.innerHTML = '';
+      for (const item of summaryItems) {
+        const pill = document.createElement('div');
+        pill.className = 'stat-pill';
+        const label = document.createElement('div');
+        label.className = 'label';
+        label.textContent = item.label;
+        const value = document.createElement('div');
+        value.className = 'value';
+        value.textContent = item.value;
+        pill.appendChild(label);
+        pill.appendChild(value);
+        statsSummaryEl.appendChild(pill);
+      }
+
+      statsSummaryEl.hidden = false;
+      guildStatsBody.innerHTML = '';
+
+      for (const guild of guilds) {
+        const tr = document.createElement('tr');
+
+        const guildCell = document.createElement('td');
+        guildCell.className = 'guild-cell';
+        if (guild.iconUrl) {
+          const img = document.createElement('img');
+          img.src = guild.iconUrl;
+          img.alt = guild.name || guild.id;
+          img.className = 'guild-icon';
+          guildCell.appendChild(img);
+        }
+        const guildMeta = document.createElement('div');
+        const title = document.createElement('div');
+        title.textContent = guild.name || guild.id;
+        guildMeta.appendChild(title);
+        const metaLine = document.createElement('div');
+        metaLine.className = 'meta';
+        const metaParts = [];
+        if (guild.id) metaParts.push(guild.id);
+        if (typeof guild.shardId === 'number') metaParts.push('Shard ' + guild.shardId);
+        if (guild.ownerId) metaParts.push('Owner ' + guild.ownerId);
+        metaLine.textContent = metaParts.join(' • ');
+        guildMeta.appendChild(metaLine);
+        if (guild.createdAt) {
+          const createdLine = document.createElement('div');
+          createdLine.className = 'meta';
+          createdLine.textContent = 'Created ' + new Date(guild.createdAt).toLocaleString();
+          guildMeta.appendChild(createdLine);
+        }
+        guildCell.appendChild(guildMeta);
+        tr.appendChild(guildCell);
+
+        const membersCell = document.createElement('td');
+        membersCell.textContent = formatNumber(guild.memberCount);
+        tr.appendChild(membersCell);
+
+        const onlineCell = document.createElement('td');
+        onlineCell.textContent = formatNumber(guild.approxPresenceCount);
+        tr.appendChild(onlineCell);
+
+        const channelsCell = document.createElement('td');
+        const counts = guild.channelCounts || {};
+        const breakdown = [];
+        if (counts.text) breakdown.push(`${formatNumber(counts.text)} text`);
+        if (counts.voice) breakdown.push(`${formatNumber(counts.voice)} voice`);
+        if (counts.forum) breakdown.push(`${formatNumber(counts.forum)} forum`);
+        if (counts.stage) breakdown.push(`${formatNumber(counts.stage)} stage`);
+        if (counts.announcement) breakdown.push(`${formatNumber(counts.announcement)} announcement`);
+        if (counts.thread) breakdown.push(`${formatNumber(counts.thread)} thread`);
+        if (counts.category) breakdown.push(`${formatNumber(counts.category)} category`);
+        const channelSummary = formatNumber(counts.total) + (breakdown.length ? ` (${breakdown.join(', ')})` : '');
+        channelsCell.textContent = channelSummary;
+        tr.appendChild(channelsCell);
+
+        const rolesCell = document.createElement('td');
+        rolesCell.textContent = formatNumber(guild.roleCount);
+        tr.appendChild(rolesCell);
+
+        const emojiCell = document.createElement('td');
+        const emojiParts = [];
+        emojiParts.push(`${formatNumber(guild.emojiCount)} emoji`);
+        emojiParts.push(`${formatNumber(guild.stickerCount)} stickers`);
+        emojiCell.textContent = emojiParts.join(', ');
+        tr.appendChild(emojiCell);
+
+        const boostCell = document.createElement('td');
+        const tier = typeof guild.boostLevel === 'number' ? guild.boostLevel : null;
+        const boostValue = formatNumber(guild.boostCount);
+        boostCell.textContent = tier !== null ? `${boostValue} (Tier ${tier})` : boostValue;
+        tr.appendChild(boostCell);
+
+        guildStatsBody.appendChild(tr);
+      }
+
+      guildStatsWrapper.hidden = guilds.length === 0;
+      if (!guilds.length) {
+        statsStatusEl.textContent = 'No guilds available for the current filter.';
+      }
+    }
+
+    function refreshAll() {
+      fetchStats();
+      fetchUsers();
     }
 
     async function login(username, password) {
@@ -872,13 +1311,14 @@ export class DashboardService {
       });
     });
 
-    refreshBtn.addEventListener('click', () => fetchUsers());
+    refreshBtn.addEventListener('click', () => refreshAll());
     logoutBtn.addEventListener('click', () => logout());
 
     updateView();
     if (isAuthenticated) {
-      fetchUsers();
+      refreshAll();
     } else {
+      statsStatusEl.textContent = 'You must sign in to view server metrics.';
       fetchSession();
     }
   </script>


### PR DESCRIPTION
## Summary
- add an authenticated `/api/stats` endpoint that aggregates guild-wide counts using the Discord client
- surface server overview cards and guild breakdown table in the private dashboard UI with reusable refresh handling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e224aade50832baf1922c6b43f1f0f