### PR TITLE
Add comprehensive tests for utility helpers

### DIFF
--- a/test/utils/discordUsers.test.js
+++ b/test/utils/discordUsers.test.js
@@ -1,0 +1,36 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { formatUserTag, getAvatarUrl, safeTimestamp } from "../../src/utils/discordUsers.js";
+
+test("formatUserTag prefers tag then username/discriminator", () => {
+  assert.equal(formatUserTag({ tag: "User#1234" }), "User#1234");
+  assert.equal(formatUserTag({ username: "User", discriminator: "42" }), "User#42");
+  assert.equal(formatUserTag({ username: "User", discriminator: "0" }), "User");
+  assert.equal(formatUserTag({ globalName: "Global" }), "Global");
+  assert.equal(formatUserTag({ id: "1" }), "1");
+  assert.equal(formatUserTag(null), "Unknown");
+});
+
+test("getAvatarUrl returns null when missing or throws", () => {
+  const withAvatar = {
+    displayAvatarURL: ({ size }) => `url-${size}`
+  };
+  assert.equal(getAvatarUrl(withAvatar, { size: 128 }), "url-128");
+
+  const throwing = {
+    displayAvatarURL() {
+      throw new Error("fail");
+    }
+  };
+  assert.equal(getAvatarUrl(throwing), null);
+  assert.equal(getAvatarUrl(null), null);
+});
+
+test("safeTimestamp normalizes numeric and Date values", () => {
+  const now = Date.now();
+  assert.equal(safeTimestamp(now), now);
+  const date = new Date(now + 1000);
+  assert.equal(safeTimestamp(date), date.getTime());
+  assert.equal(safeTimestamp("not"), null);
+  assert.equal(safeTimestamp(new Date("invalid")), null);
+});

--- a/test/utils/embeds.test.js
+++ b/test/utils/embeds.test.js
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EmbedBuilder } from "discord.js";
+import {
+  baseEmbed,
+  infoEmbed,
+  successEmbed,
+  errorEmbed,
+  listEmbed
+} from "../../src/utils/embeds.js";
+
+const getData = (embed) => embed.data;
+
+test("baseEmbed returns a new EmbedBuilder", () => {
+  const embed = baseEmbed();
+  assert.ok(embed instanceof EmbedBuilder);
+  assert.notStrictEqual(baseEmbed(), embed);
+});
+
+test("info, success, and error embeds set title and description", () => {
+  const info = getData(infoEmbed("Info", "Details"));
+  const success = getData(successEmbed("Success", "Done"));
+  const error = getData(errorEmbed("Error", "Failure"));
+
+  assert.equal(info.title, "Info");
+  assert.equal(info.description, "Details");
+
+  assert.equal(success.title, "Success");
+  assert.equal(success.description, "Done");
+
+  assert.equal(error.title, "Error");
+  assert.equal(error.description, "Failure");
+});
+
+test("listEmbed joins items and uses fallback when empty", () => {
+  const joined = getData(listEmbed("List", ["a", "b"]));
+  const fallback = getData(listEmbed("Empty", [], "None"));
+
+  assert.equal(joined.description, "a\nb");
+  assert.equal(fallback.description, "None");
+});

--- a/test/utils/emojiImporter.test.js
+++ b/test/utils/emojiImporter.test.js
@@ -1,0 +1,136 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  extractCustomEmojis,
+  getEmojiCdnUrl,
+  sanitizeEmojiName,
+  isValidEmojiName,
+  ensureUniqueEmojiName,
+  fetchExistingEmojiNames,
+  ensureBotEmojiPermissions,
+  fetchEmojiAttachment,
+  createEmojiFromCdn,
+  createEmojiFromUrl
+} from "../../src/utils/emojiImporter.js";
+import { PermissionFlagsBits } from "discord.js";
+
+test("extractCustomEmojis parses animated flag and identifiers", () => {
+  const results = extractCustomEmojis("hello <a:test:123456789012345678> and <:static:876543210987654321>");
+  assert.deepEqual(results, [
+    { animated: true, originalName: "test", id: "123456789012345678" },
+    { animated: false, originalName: "static", id: "876543210987654321" }
+  ]);
+  assert.equal(getEmojiCdnUrl(results[0]), "https://cdn.discordapp.com/emojis/123456789012345678.gif");
+});
+
+test("sanitize and ensureUniqueEmojiName enforce Discord constraints", () => {
+  const used = new Set(["taken"]);
+  assert.equal(sanitizeEmojiName("!"), "__");
+  assert.equal(isValidEmojiName("valid_name"), true);
+  const unique = ensureUniqueEmojiName("taken", used);
+  assert.ok(unique.startsWith("taken"));
+  assert.ok(used.has(unique));
+});
+
+test("fetchExistingEmojiNames collects names from guild cache", async () => {
+  const guild = {
+    emojis: {
+      async fetch() {
+        return new Map([
+          ["1", { name: "one" }],
+          ["2", { name: null }],
+          ["3", { name: "two" }]
+        ]);
+      }
+    }
+  };
+  const names = await fetchExistingEmojiNames(guild);
+  assert.deepEqual([...names.values()].sort(), ["one", "two"]);
+});
+
+test("ensureBotEmojiPermissions throws when Manage Guild Expressions missing", async () => {
+  const interaction = { guild: { members: { me: { permissions: { has: () => false } } } } };
+  await assert.rejects(() => ensureBotEmojiPermissions(interaction));
+
+  const okInteraction = { guild: { members: { me: { permissions: { has: (bit) => bit === PermissionFlagsBits.ManageGuildExpressions } } } } };
+  await assert.doesNotReject(() => ensureBotEmojiPermissions(okInteraction));
+});
+
+test("fetchEmojiAttachment validates responses", async (t) => {
+  const originalFetch = global.fetch;
+  t.after(() => { global.fetch = originalFetch; });
+
+  const data = Buffer.from([1, 2, 3]);
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: (name) => (name === "content-type" ? "image/png" : null) },
+    async arrayBuffer() { return data; }
+  });
+
+  const { buffer, extension } = await fetchEmojiAttachment("https://example.com/emoji.png");
+  assert.equal(buffer.length, 3);
+  assert.equal(extension, "png");
+
+  global.fetch = async () => ({ ok: false, status: 404 });
+  await assert.rejects(() => fetchEmojiAttachment("https://bad"));
+
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: () => "text/plain" },
+    async arrayBuffer() { return new Uint8Array([1]).buffer; }
+  });
+  await assert.rejects(() => fetchEmojiAttachment("https://badtype"));
+});
+
+test("createEmojiFromCdn downloads emoji and creates guild emoji", async (t) => {
+  const used = new Set();
+  const guild = {
+    emojis: {
+      create: t.mock.fn(async ({ attachment, name }) => ({ attachment, name }))
+    }
+  };
+
+  const originalFetch = global.fetch;
+  t.after(() => { global.fetch = originalFetch; });
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: () => "image/gif" },
+    async arrayBuffer() { return new Uint8Array([1]).buffer; }
+  });
+
+  const name = await createEmojiFromCdn(guild, { id: "1", animated: true, originalName: "emoji" }, used, "reason");
+  assert.equal(name, "emoji");
+  assert.equal(used.has("emoji"), true);
+  assert.equal(guild.emojis.create.mock.calls.length, 1);
+  const call = guild.emojis.create.mock.calls[0].arguments[0];
+  assert.equal(call.name, "emoji");
+  assert.equal(call.attachment.name, "emoji.gif");
+});
+
+test("createEmojiFromUrl uses provided name and extension", async (t) => {
+  const used = new Set();
+  const guild = {
+    emojis: {
+      create: t.mock.fn(async ({ name }) => ({ name }))
+    }
+  };
+
+  const originalFetch = global.fetch;
+  t.after(() => { global.fetch = originalFetch; });
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: () => "image/png" },
+    async arrayBuffer() { return new Uint8Array([2]).buffer; }
+  });
+
+  const name = await createEmojiFromUrl(guild, "custom", "https://url", used, "reason");
+  assert.equal(name, "custom");
+  assert.equal(guild.emojis.create.mock.calls.length, 1);
+  const call = guild.emojis.create.mock.calls[0].arguments[0];
+  assert.equal(call.name, "custom");
+  assert.equal(call.attachment.name, "custom.png");
+});

--- a/test/utils/invites.test.js
+++ b/test/utils/invites.test.js
@@ -1,0 +1,25 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { findInviteMatches, extractInviteCode, INVITE_REGEX } from "../../src/utils/invites.js";
+
+test("findInviteMatches extracts unique invite codes and positions", () => {
+  const text = "Join https://discord.gg/Example and discord.com/invite/example";
+  const matches = findInviteMatches(text);
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].code.toLowerCase(), "example");
+  assert.ok(matches[0].index >= 0);
+});
+
+test("extractInviteCode handles direct codes and URLs", () => {
+  assert.equal(extractInviteCode("example"), "example");
+  assert.equal(extractInviteCode("https://discord.gg/Example"), "Example");
+  assert.equal(extractInviteCode("<discord.gg/test>").toLowerCase(), "test");
+  assert.equal(extractInviteCode(null), null);
+});
+
+test("INVITE_REGEX matches various domains", () => {
+  const text = "discordapp.com/invite/Code";
+  const match = INVITE_REGEX.exec(text);
+  assert.ok(match);
+  assert.equal(match[1], text);
+});

--- a/test/utils/logger.test.js
+++ b/test/utils/logger.test.js
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { Logger } from "../../src/utils/logger.js";
+
+test("logger buffers entries, mirrors, and rate limits", async (t) => {
+  const originalNow = Date.now;
+  let now = 0;
+  Date.now = () => now;
+  t.after(() => {
+    Date.now = originalNow;
+  });
+
+  const lines = [];
+  t.mock.method(console, "log", (line) => { lines.push({ level: "log", line }); });
+  t.mock.method(console, "warn", (line) => { lines.push({ level: "warn", line }); });
+  t.mock.method(console, "error", (line) => { lines.push({ level: "error", line }); });
+
+  const mirrorCalls = [];
+  const logger = new Logger({
+    level: "info",
+    rateLimit: { intervalMs: 1000, burst: 1 },
+    mirrorFn: async (payload) => { mirrorCalls.push(payload); }
+  });
+
+  await logger.info("first", { value: 1 });
+  assert.equal(logger.tail(1)[0].msg, "first");
+  assert.equal(mirrorCalls.length, 1);
+
+  now += 10;
+  await logger.info("suppressed");
+  const afterSuppressed = logger.tail(2);
+  assert.equal(afterSuppressed.length, 2);
+  assert.equal(afterSuppressed[afterSuppressed.length - 1].msg, "logger.rate_limit.hit");
+  assert.equal(mirrorCalls.length, 1, "suppressed logs do not mirror");
+
+  now += 2000;
+  await logger.info("second");
+  const tail = logger.tail(4);
+  assert.equal(tail[tail.length - 2].msg, "logger.rate_limit.flush");
+  assert.equal(tail[tail.length - 1].msg, "second");
+  assert.equal(mirrorCalls.length, 2, "second allowed log mirrors");
+
+  const flushWarning = lines.find((entry) => entry.level === "warn" && entry.line.includes("logger.rate_limit.flush"));
+  assert.ok(flushWarning, "rate limit flush warning emitted");
+});
+
+test("logger setLevel ignores unknown levels", () => {
+  const logger = new Logger({ rateLimit: null });
+  logger.setLevel("debug");
+  assert.equal(logger.level, "debug");
+  logger.setLevel("nope");
+  assert.equal(logger.level, "debug");
+});

--- a/test/utils/memberLog.test.js
+++ b/test/utils/memberLog.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+test("getMemberLogColors merges config overrides with fallbacks", async () => {
+  const url = new URL("../../src/utils/memberLog.js", import.meta.url);
+  const source = await readFile(url, "utf8");
+  const patched = source.replace(
+    'import { CONFIG } from "../config.js";',
+    'const CONFIG = { colors: { green: 0x010203, default: 0x0a0b0c } };'
+  );
+  const moduleUrl = `data:text/javascript;base64,${Buffer.from(patched).toString("base64")}`;
+  const { getMemberLogColors } = await import(moduleUrl);
+  assert.deepEqual(getMemberLogColors(), {
+    join: 0x010203,
+    leave: 0xED4245,
+    neutral: 0x0a0b0c
+  });
+});

--- a/test/utils/memberLogEmbeds.test.js
+++ b/test/utils/memberLogEmbeds.test.js
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createMemberEmbedBase } from "../../src/utils/memberLogEmbeds.js";
+
+test("createMemberEmbedBase populates author, footer, and thumbnail", () => {
+  const member = {
+    id: "123",
+    user: {
+      id: "123",
+      tag: "Member#123",
+      displayAvatarURL: () => "https://cdn.example/avatar.png"
+    }
+  };
+
+  const { embed, user } = createMemberEmbedBase({
+    member,
+    title: "Joined",
+    color: 0xabcdef
+  });
+
+  const data = embed.data;
+  assert.equal(data.title, "Joined");
+  assert.equal(data.color, 0xabcdef);
+  assert.ok(data.timestamp);
+  assert.equal(data.footer.text, "ID: 123");
+  assert.equal(data.author.name, "Member#123");
+  assert.equal(data.author.icon_url, "https://cdn.example/avatar.png");
+  assert.equal(data.thumbnail.url, "https://cdn.example/avatar.png");
+  assert.equal(user, member.user);
+});

--- a/test/utils/snowflake.test.js
+++ b/test/utils/snowflake.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { decodeSnowflake, formatDiscordTimestamp, DISCORD_EPOCH_MS } from "../../src/utils/snowflake.js";
+
+test("decodeSnowflake converts ids into millisecond timestamps", () => {
+  const ms = DISCORD_EPOCH_MS + 12345;
+  const snowflake = ((BigInt(ms - DISCORD_EPOCH_MS)) << 22n).toString();
+  assert.equal(decodeSnowflake(snowflake), ms);
+  assert.equal(decodeSnowflake("not"), null);
+  assert.equal(decodeSnowflake(-1), null);
+});
+
+test("formatDiscordTimestamp formats unix seconds with optional style", () => {
+  const ms = 1_600_000_000_000;
+  const seconds = Math.floor(ms / 1000);
+  assert.equal(formatDiscordTimestamp(ms), `<t:${seconds}>`);
+  assert.equal(formatDiscordTimestamp(ms, "F"), `<t:${seconds}:F>`);
+  assert.equal(formatDiscordTimestamp(-1), null);
+});


### PR DESCRIPTION
## Summary
- add coverage for Discord utility helpers including embeds, users, invites, snowflake handling, and logger behavior
- exercise emoji import workflows and member log helpers to ensure fallback logic and rate limits work as expected

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2266fcd10832ba11236ea7f7f98d7