### PR TITLE
Refactor loader to use async utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "any-ascii": "^0.3.3",
-        "async": "^3.2.5",
+        "async": "^3.2.6",
         "bcryptjs": "^2.4.3",
         "chalk": "^5.3.0",
         "discord.js": "^14.16.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "any-ascii": "^0.3.3",
-    "async": "^3.2.5",
+    "async": "^3.2.6",
     "discord.js": "^14.16.3",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",


### PR DESCRIPTION
## Summary
- replace the local concurrency helper with the async library and centralize concurrency parsing
- enhance registry loader logging with chalk formatting and improved plugin loading flow
- bump async dependency to 3.2.6 so the runtime can resolve the package from ESM entrypoints

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e22eae8fd4832b83416d561cae8322