### PR TITLE
Fix deploy CLI module imports

### DIFF
--- a/tools/cli/deploy-commands.js
+++ b/tools/cli/deploy-commands.js
@@ -2,8 +2,8 @@ import asyncLib from "async";
 import chalk from "chalk";
 import { REST, Routes } from "discord.js";
 import { join, resolve } from "node:path";
-import { CONFIG } from "../src/config/index.js";
-import { loadPlugins, walkFiles } from "../src/app/registry/loader.js";
+import { CONFIG } from "../../src/config/index.js";
+import { loadPlugins, walkFiles } from "../../src/app/registry/loader.js";
 
 async function collectAllCommands() {
   const roots = [join(process.cwd(), "src", "features", "commands")];


### PR DESCRIPTION
## Summary
- fix the deploy CLI script so it imports the shared config and loader modules from the correct location

## Testing
- not run (requires Discord API credentials)


------
https://chatgpt.com/codex/tasks/task_e_68e22fe217e0832b8190a821e7fc0f40