### PR TITLE
Add default environment template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ web_modules/
 .env
 .env.*
 !.env.example
+!env.default
 
 config.json
 !default.config.json

--- a/env.default
+++ b/env.default
@@ -1,0 +1,14 @@
+# Default environment configuration for wiz-bot.
+# Copy this file to .env and customize the values as needed.
+
+# Discord application credentials
+DISCORD_TOKEN=
+DISCORD_CLIENT_ID=
+
+# Database connection
+MONGO_URI=
+
+# Optional configuration overrides
+LOG_LEVEL=info
+DEV_GUILD_IDS=
+PRIVATE_MODULE_DIRS=


### PR DESCRIPTION
## Summary
- add an `env.default` template with commonly configured environment variables
- ensure `env.default` is not ignored by git so it is version controlled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e233efa950832b876f1e7c3809c286