### PR TITLE
Add getOptional container helper for optional bindings

### DIFF
--- a/src/app/container/index.js
+++ b/src/app/container/index.js
@@ -1,9 +1,21 @@
 export class Container {
   #map = new Map();
   set(key, value) { this.#map.set(key, value); }
+  /**
+   * Retrieve a dependency that must be present in the container.
+   * Prefer {@link getOptional} when the binding is optional.
+   * @throws {Error} When the binding is missing.
+   */
   get(key) {
     if (!this.#map.has(key)) throw new Error(`Container missing: ${key}`);
     return this.#map.get(key);
+  }
+  /**
+   * Retrieve an optional dependency. Returns {@code null} when the binding
+   * is absent instead of throwing like {@link get}.
+   */
+  getOptional(key) {
+    return this.#map.has(key) ? this.#map.get(key) ?? null : null;
   }
   has(key) {
     return this.#map.has(key);

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -101,10 +101,10 @@ async function main() {
   client.container = container;
   client.commands = new Map();
 
-  if (container.has(TOKENS.DashboardService)) {
+  const dashboardService = container.getOptional(TOKENS.DashboardService);
+  if (dashboardService) {
     try {
-      const dashboardService = container.get(TOKENS.DashboardService);
-      dashboardService?.setClient?.(client);
+      dashboardService.setClient?.(client);
     } catch (error) {
       logger?.error?.("dashboard.attach_failed", { error: String(error?.message || error) });
     }

--- a/src/features/events/memberLogShared.js
+++ b/src/features/events/memberLogShared.js
@@ -11,10 +11,10 @@ export function formatMemberLine(member, user) {
 
 export function getLogger(container) {
   if (!container) return null;
-  try { return container.get(TOKENS.Logger); } catch { return null; }
+  return container.getOptional?.(TOKENS.Logger) ?? null;
 }
 
 export function getStaffMemberLogService(container) {
   if (!container) return null;
-  try { return container.get(TOKENS.StaffMemberLogService); } catch { return null; }
+  return container.getOptional?.(TOKENS.StaffMemberLogService) ?? null;
 }

--- a/src/features/events/messageCreate.mention-tracker.js
+++ b/src/features/events/messageCreate.mention-tracker.js
@@ -9,28 +9,20 @@ export default {
     const container = message.client?.container;
     if (!container) return;
 
-    let mentionTracker;
-    try {
-      mentionTracker = container.get(TOKENS.MentionTrackerService);
-    } catch {
-      return;
-    }
+    const mentionTracker = container.getOptional(TOKENS.MentionTrackerService);
+    if (!mentionTracker) return;
 
     if (!mentionTracker?.handleMessage) return;
 
     try {
       await mentionTracker.handleMessage(message);
     } catch (error) {
-      try {
-        const logger = container.get(TOKENS.Logger);
-        logger?.warn?.("mention_tracker.handle_failed", {
-          guildId: message.guildId,
-          messageId: message.id,
-          error: String(error?.message || error)
-        });
-      } catch {
-        // ignore logging failures
-      }
+      const logger = container.getOptional(TOKENS.Logger);
+      logger?.warn?.("mention_tracker.handle_failed", {
+        guildId: message.guildId,
+        messageId: message.id,
+        error: String(error?.message || error)
+      });
     }
   }
 };

--- a/tests/unit/app/container.test.js
+++ b/tests/unit/app/container.test.js
@@ -13,3 +13,15 @@ test("get throws for unknown tokens", () => {
   const container = new Container();
   assert.throws(() => container.get("missing"), /Container missing: missing/);
 });
+
+test("getOptional returns null when binding is missing", () => {
+  const container = new Container();
+  assert.equal(container.getOptional("missing"), null);
+});
+
+test("getOptional returns stored value", () => {
+  const container = new Container();
+  const instance = { id: 456 };
+  container.set("another", instance);
+  assert.equal(container.getOptional("another"), instance);
+});


### PR DESCRIPTION
## Summary
- add a getOptional helper to the container to support optional dependencies and document the distinction from get
- switch optional consumers such as the mention tracker and member log helpers to use the new helper
- use the helper when wiring the dashboard service and cover the new behavior with unit tests

## Testing
- npm test *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'jsonc-parser')*


------
https://chatgpt.com/codex/tasks/task_e_68e235a49870832b91e8d8eb638f60d3