### PR TITLE
Refactor plugin loader to pass host context

### DIFF
--- a/src/app/registry/loader.js
+++ b/src/app/registry/loader.js
@@ -84,11 +84,22 @@ export async function loadPlugins(pluginDirs = []) {
     if (!entry?.setup) return null;
 
     const reg = await entry.setup();
+    if (!reg) return null;
+
     // normalize
     reg.commandDirs = reg.commandDirs || [];
     reg.eventDirs = reg.eventDirs || [];
     reg.intents = reg.intents || [];
     reg.partials = reg.partials || [];
+    if (typeof reg.register === "function") {
+      const originalRegister = reg.register;
+      reg.register = async (container, context) => {
+        if (originalRegister.length >= 2) {
+          return originalRegister(container, context);
+        }
+        return originalRegister(container);
+      };
+    }
     return reg;
   };
 

--- a/src/app/registry/plugin.js
+++ b/src/app/registry/plugin.js
@@ -1,12 +1,21 @@
 // Minimal, framework-agnostic plugin contract
 
 /**
+ * @typedef {Object} PluginContext
+ * @property {typeof import("../../config/index.js").CONFIG} config
+ * @property {typeof import("../container/index.js").TOKENS} tokens
+ * @property {typeof import("../../shared/utils/logger.js").Logger} loggerClass
+ * @property {{ [key: string]: any }} [helpers]
+ * @property {{ [key: string]: any }} [models]
+ */
+
+/**
  * @typedef {Object} PluginRegistration
  * @property {string[]} [commandDirs]  absolute or relative directories with command .js files (default export)
  * @property {string[]} [eventDirs]    directories with event .js files (default export {name, once, execute})
  * @property {number[]} [intents]      extra Discord intents needed by this plugin
  * @property {number[]} [partials]     extra Discord partials needed by this plugin
- * @property {(container:{set:(k:string,v:any)=>void, get:(k:string)=>any})=>Promise<void>|void} [register]
+ * @property {(container:{set:(k:string,v:any)=>void, get:(k:string)=>any}, context:PluginContext)=>Promise<void>|void} [register]
  */
 
 /**


### PR DESCRIPTION
## Summary
- normalize plugin registration to accept an optional host-provided context
- expose configuration, tokens, helpers, and models to plugins and update the private plugin to consume them
- document the register(container, context) signature for plugin authors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e235a2b22c832ba448244d29f2fa1d