### PR TITLE
Fix antiraid command embed import path

### DIFF
--- a/extensions/bot-private/src/features/commands/antiraid.js
+++ b/extensions/bot-private/src/features/commands/antiraid.js
@@ -1,6 +1,6 @@
 import { PermissionFlagsBits, SlashCommandBuilder, MessageFlags } from "discord.js";
 import { PRIVATE_TOKENS } from "../../domain/services/tokens.js";
-import { infoEmbed } from "../../../../src/shared/utils/embeds.js";
+import { infoEmbed } from "../../../../../src/shared/utils/embeds.js";
 
 const svc = (ix) => ix.client.container.get(PRIVATE_TOKENS.AntiRaidService);
 


### PR DESCRIPTION
## Summary
- fix the antiraid command's infoEmbed import to point at the shared utilities in the main src directory

## Testing
- npm run deploy *(fails: .env not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e23c29aad0832b966a90fbda5ff76a