### PR TITLE
Handle HTML login submissions with redirect

### DIFF
--- a/extensions/bot-private/src/domain/services/__tests__/DashboardService.test.js
+++ b/extensions/bot-private/src/domain/services/__tests__/DashboardService.test.js
@@ -114,3 +114,25 @@ test("dashboard exposes a clickable url", async (t) => {
 
   assert.equal(service.getUrl(), `http://localhost:${port}${basePath}`);
 });
+
+test("dashboard login redirects html form submissions to the dashboard", async (t) => {
+  const hash = await bcrypt.hash("s3cret", 4);
+  const basePath = "/panel";
+  const { service, port } = await createService({ passwordHash: hash, basePath });
+  t.after(async () => {
+    await service.stop();
+  });
+
+  const res = await fetch(`http://127.0.0.1:${port}${basePath}/auth/login`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Accept": "text/html,application/xhtml+xml"
+    },
+    body: new URLSearchParams({ username: "admin", password: "s3cret" }),
+    redirect: "manual"
+  });
+
+  assert.equal(res.status, 303);
+  assert.equal(res.headers.get("location"), basePath);
+});


### PR DESCRIPTION
## Summary
- detect HTML form submissions during dashboard login and redirect to the configured base path after success
- keep JSON responses for API clients and cover the redirect path with a regression test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e24e124a2c832b86354e8b0029ea51