### PR TITLE
Avoid stale session poll overriding login state

### DIFF
--- a/extensions/bot-private/src/domain/services/DashboardService.js
+++ b/extensions/bot-private/src/domain/services/DashboardService.js
@@ -3034,11 +3034,13 @@ export class DashboardService {
         const data = await res.json();
         if (data.authenticated) {
           setAuthenticated(true, data.username || '');
-        } else {
+        } else if (!isAuthenticated) {
           setAuthenticated(false, '');
         }
       } catch {
-        setAuthenticated(false, '');
+        if (!isAuthenticated) {
+          setAuthenticated(false, '');
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- prevent the initial session poll from resetting the authenticated dashboard view after login
- ensure the dashboard stays visible once the session has been established

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2502a301c832b93064ac92133e1f2